### PR TITLE
feat : 포스팅 이미지 업로드 추가

### DIFF
--- a/src/main/java/com/donation/common/response/post/PostFindRespDto.java
+++ b/src/main/java/com/donation/common/response/post/PostFindRespDto.java
@@ -2,11 +2,9 @@ package com.donation.common.response.post;
 
 import com.donation.common.response.user.UserRespDto;
 import com.donation.domain.embed.Write;
-import com.donation.domain.entites.Post;
 import com.donation.domain.enums.Category;
 import com.donation.domain.enums.PostState;
 import com.querydsl.core.annotations.QueryProjection;
-import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
@@ -40,28 +38,8 @@ public class PostFindRespDto {
         this.state = state;
     }
 
-
-    @Builder
-    public PostFindRespDto(Long postId, UserRespDto userRespDto, Write write, int amount, Category category, PostState state, List<String> postDetailImages, Integer favoriteCount) {
-        this.postId = postId;
-        this.userRespDto = userRespDto;
-        this.write = write;
-        this.amount = amount;
-        this.category = category;
-        this.state = state;
+    public PostFindRespDto addPostDetailImages(List<String> postDetailImages){
         this.postDetailImages = postDetailImages;
-        this.favoriteCount = favoriteCount;
-    }
-
-    public static PostFindRespDto toDto(Post post){
-        return PostFindRespDto.builder()
-                .postId(post.getId())
-                .userRespDto(new UserRespDto(post.getUser()))
-                .write(new Write(post))
-                .amount(post.getAmount())
-                .state(post.getState())
-                .postDetailImages(null)
-                .favoriteCount(null)
-                .build();
+        return this;
     }
 }

--- a/src/main/java/com/donation/common/response/post/PostSaveRespDto.java
+++ b/src/main/java/com/donation/common/response/post/PostSaveRespDto.java
@@ -3,6 +3,7 @@ package com.donation.common.response.post;
 import com.donation.common.response.user.UserRespDto;
 import com.donation.domain.embed.Write;
 import com.donation.domain.entites.Post;
+import com.donation.domain.entites.PostDetailImage;
 import com.donation.domain.entites.User;
 import com.donation.domain.enums.Category;
 import com.donation.domain.enums.PostState;
@@ -10,23 +11,16 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class PostSaveRespDto {
-
     private Long postId;
-
     private UserRespDto userRespDto;
-
     private Write write;
-
     private int amount;
-
     private Category category;
-
     private PostState state;
-
-    //이미지 정보 추가 기입
     private List<String> postDetailImages;
 
     @Builder
@@ -47,6 +41,11 @@ public class PostSaveRespDto {
                 .write(new Write(post))
                 .amount(post.getAmount())
                 .state(post.getState())
+                .postDetailImages(
+                        post.getPostDetailImages().stream()
+                        .map(PostDetailImage::getImagePath)
+                        .collect(Collectors.toList())
+                )
                 .build();
     }
 }

--- a/src/main/java/com/donation/domain/entites/Post.java
+++ b/src/main/java/com/donation/domain/entites/Post.java
@@ -41,20 +41,23 @@ public class Post extends BaseEntity {
     @Enumerated(STRING)
     private PostState state;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<PostDetailImage> postDetailImages = new ArrayList<>();
 
     @Builder
-    public Post(Long id, User user, Write write, int amount, Category category, PostState state, List<PostDetailImage> postDetailImages) {
+    public Post(Long id, User user, Write write, int amount, Category category, PostState state) {
         this.id = id;
         this.user = user;
         this.write = write;
         this.amount = amount;
         this.category = category;
         this.state = state;
-        this.postDetailImages = postDetailImages;
     }
 
+    public void addPostImage(PostDetailImage postDetailImage){
+        postDetailImage.setPost(this);
+        this.getPostDetailImages().add(postDetailImage);
+    }
 
     public Post update(PostUpdateReqDto dto) {
         this.write = Write.builder()

--- a/src/main/java/com/donation/domain/entites/PostDetailImage.java
+++ b/src/main/java/com/donation/domain/entites/PostDetailImage.java
@@ -30,4 +30,8 @@ public class PostDetailImage extends BaseEntity{
         this.post = post;
         this.imagePath = imagePath;
     }
+
+    public void setPost(Post post) {
+        this.post = post;
+    }
 }

--- a/src/main/java/com/donation/repository/post/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/donation/repository/post/PostRepositoryCustomImpl.java
@@ -29,12 +29,12 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                 .select(new QPostFindRespDto(
                         post.id.as("postId"),
                         user.id.as("userId"),
-                        user.username.as("username"),
-                        user.name.as("name"),
-                        user.profileImage.as("profileImage"),
-                        post.write.as("write"),
+                        user.username,
+                        user.name,
+                        user.profileImage,
+                        post.write,
                         post.amount,
-                        post.category.as("category"),
+                        post.category,
                         post.state.as("postState")
                 ))
                 .from(post)
@@ -45,9 +45,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                 .stream().findAny();
     }
 
-
     @Override
-
     public Slice<PostListRespDto> findDetailPostAll(Pageable pageable, PostState... postStates) {
         List<PostListRespDto> content = queryFactory
                 .select(new QPostListRespDto(

--- a/src/main/java/com/donation/repository/postdetailimage/PostDetailImageRepository.java
+++ b/src/main/java/com/donation/repository/postdetailimage/PostDetailImageRepository.java
@@ -1,0 +1,13 @@
+package com.donation.repository.postdetailimage;
+
+import com.donation.domain.entites.PostDetailImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PostDetailImageRepository extends JpaRepository<PostDetailImage, Long> {
+    @Query("select p.imagePath from PostDetailImage p where p.post.id = :id")
+    List<String> findImagePath(@Param("id") Long postId);
+}

--- a/src/main/java/com/donation/service/post/PostService.java
+++ b/src/main/java/com/donation/service/post/PostService.java
@@ -6,20 +6,26 @@ import com.donation.common.response.post.PostFindRespDto;
 import com.donation.common.response.post.PostListRespDto;
 import com.donation.common.response.post.PostSaveRespDto;
 import com.donation.domain.entites.Post;
+import com.donation.domain.entites.PostDetailImage;
 import com.donation.domain.entites.User;
 import com.donation.domain.enums.PostState;
 import com.donation.repository.post.PostRepository;
+import com.donation.repository.postdetailimage.PostDetailImageRepository;
+import com.donation.service.s3.AwsS3Service;
 import com.donation.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 
-import static com.donation.domain.enums.PostState.*;
+import static com.donation.domain.enums.PostState.DELETE;
 
 @Service
 @RequiredArgsConstructor
@@ -27,13 +33,36 @@ import static com.donation.domain.enums.PostState.*;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final PostDetailImageRepository postDetailImageRepository;
     private final UserService userService;
+    private final AwsS3Service awsS3Service;
 
-    public PostSaveRespDto save(PostSaveReqDto postSaveReqDto, Long userid){
-        User user = userService.get(userid);
-        Post post = postRepository.save(postSaveReqDto.toPost(user));
-        return PostSaveRespDto.toDto(post, user);
+    public PostSaveRespDto save(PostSaveReqDto postSaveReqDto, List<MultipartFile> images, Long userId){
+        User user = userService.get(userId);
+        Post post = postRepository.save(postSaveValidation(postSaveReqDto, images, user));
+        return  PostSaveRespDto.toDto(post, user);
     }
+
+    private Post postSaveValidation(PostSaveReqDto postSaveReqDto, List<MultipartFile> images, User user) {
+        Post post = postSaveReqDto.toPost(user);
+        if (images != null)
+            addPostDetailImage(images, post);
+        return post;
+    }
+
+    private void addPostDetailImage(List<MultipartFile> images, Post post) {
+        for (MultipartFile image : images) {
+            if (!StringUtils.hasText(image.getOriginalFilename())) {
+                continue;
+            }
+            String imagePath = awsS3Service.upload(image);
+            PostDetailImage build = PostDetailImage.builder()
+                    .imagePath(imagePath)
+                    .build();
+            post.addPostImage(build);
+        }
+    }
+
 
     public void update(PostUpdateReqDto updateReqDto, Long id){
         Post post = postRepository.findById(id)
@@ -54,8 +83,10 @@ public class PostService {
     }
 
     public PostFindRespDto findById(Long postId) {
-        return postRepository.findDetailPostById(postId)
+        PostFindRespDto findPostDto = postRepository.findDetailPostById(postId)
                 .orElseThrow(IllegalArgumentException::new);
+        List<String> imagePath = postDetailImageRepository.findImagePath(findPostDto.getPostId());
+        return findPostDto.addPostDetailImages(imagePath);
     }
 
     public Slice<PostListRespDto> getList(Pageable pageable, PostState... states) {

--- a/src/main/java/com/donation/service/s3/AwsS3Service.java
+++ b/src/main/java/com/donation/service/s3/AwsS3Service.java
@@ -33,6 +33,7 @@ public class AwsS3Service {
         ObjectMetadata objMeta = new ObjectMetadata();
         try {
             objMeta.setContentLength(multipartFile.getInputStream().available());
+            objMeta.setContentType(multipartFile.getContentType());
             amazonS3.putObject(bucket, s3FileName, multipartFile.getInputStream(), objMeta);
         } catch (IOException e) {
             throw new FileUploadFailedException();

--- a/src/main/java/com/donation/service/user/UserService.java
+++ b/src/main/java/com/donation/service/user/UserService.java
@@ -37,8 +37,8 @@ public class UserService {
         return user.getId();
     }
 
-    public void login(UserLoginReqDto userLoginReqDto){
-        userRepository.findByUsernameAndPassword(userLoginReqDto.getEmail(), userLoginReqDto.getPassword())
+    public User login(UserLoginReqDto userLoginReqDto){
+        return userRepository.findByUsernameAndPassword(userLoginReqDto.getEmail(), userLoginReqDto.getPassword())
                 .orElseThrow(NoSuchElementException::new);
     }
 

--- a/src/main/java/com/donation/service/user/UserService.java
+++ b/src/main/java/com/donation/service/user/UserService.java
@@ -48,12 +48,10 @@ public class UserService {
                 .orElseThrow(NoSuchElementException::new);
     }
 
-
     @Transactional(readOnly = true)
     public Slice<UserRespDto> getList(Pageable pageable){
         return userRepository.findPageableAll(pageable);
     }
-
 
     public void delete(Long id){
         User user = userRepository.findById(id)

--- a/src/main/java/com/donation/web/controller/post/PostController.java
+++ b/src/main/java/com/donation/web/controller/post/PostController.java
@@ -14,8 +14,10 @@ import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
+import java.util.List;
 
 import static com.donation.domain.enums.PostState.APPROVAL;
 import static com.donation.domain.enums.PostState.COMPLETION;
@@ -29,10 +31,12 @@ public class PostController {
 
     @PostMapping
     public ResponseEntity<?> save(
-            @RequestBody @Valid PostSaveReqDto postSaveReqDto,
-            @RequestParam(name = "id") Long userId){
+            @RequestParam(name = "id") Long userId,
+            @RequestPart(value = "data") @Valid PostSaveReqDto postSaveReqDto,
+            @RequestPart(value = "images",required = false)List<MultipartFile> image
+            ){
 
-        PostSaveRespDto post = postService.save(postSaveReqDto, userId);
+        PostSaveRespDto post = postService.save(postSaveReqDto,image, userId);
         return new ResponseEntity<>(CommonResponse.success(post), HttpStatus.CREATED);
     }
 
@@ -46,7 +50,6 @@ public class PostController {
     public ResponseEntity<?> update(
             @RequestBody @Valid PostUpdateReqDto postUpdateReqDto,
             @PathVariable Long id){
-
         postService.update(postUpdateReqDto, id);
         return ResponseEntity.ok(CommonResponse.success());
     }

--- a/src/main/java/com/donation/web/controller/user/UserController.java
+++ b/src/main/java/com/donation/web/controller/user/UserController.java
@@ -4,6 +4,7 @@ import com.donation.common.CommonResponse;
 import com.donation.common.response.user.UserRespDto;
 import com.donation.common.request.user.UserJoinReqDto;
 import com.donation.common.request.user.UserLoginReqDto;
+import com.donation.domain.entites.User;
 import com.donation.service.user.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,8 +36,8 @@ public class UserController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid UserLoginReqDto userLoginReqDto){
-        userService.login(userLoginReqDto);
-        return ResponseEntity.ok(CommonResponse.success());
+        User user = userService.login(userLoginReqDto);
+        return ResponseEntity.ok(CommonResponse.success(user.getId()));
     }
 
     @GetMapping("/user")

--- a/src/main/resources/templates/docs/index.html
+++ b/src/main/resources/templates/docs/index.html
@@ -804,26 +804,26 @@ Content-Length: 1816
     } ],
     "pageable" : {
       "sort" : {
-        "empty" : true,
         "sorted" : false,
-        "unsorted" : true
+        "unsorted" : true,
+        "empty" : true
       },
-      "offset" : 0,
-      "pageSize" : 10,
       "pageNumber" : 0,
-      "unpaged" : false,
-      "paged" : true
+      "pageSize" : 10,
+      "offset" : 0,
+      "paged" : true,
+      "unpaged" : false
     },
-    "size" : 10,
     "number" : 0,
     "sort" : {
-      "empty" : true,
       "sorted" : false,
-      "unsorted" : true
+      "unsorted" : true,
+      "empty" : true
     },
+    "numberOfElements" : 10,
     "first" : true,
     "last" : false,
-    "numberOfElements" : 10,
+    "size" : 10,
     "empty" : false
   },
   "error" : null
@@ -1441,26 +1441,26 @@ Content-Length: 5167
     } ],
     "pageable" : {
       "sort" : {
-        "empty" : true,
         "sorted" : false,
-        "unsorted" : true
+        "unsorted" : true,
+        "empty" : true
       },
-      "offset" : 0,
-      "pageSize" : 10,
       "pageNumber" : 0,
-      "unpaged" : false,
-      "paged" : true
+      "pageSize" : 10,
+      "offset" : 0,
+      "paged" : true,
+      "unpaged" : false
     },
-    "size" : 10,
     "number" : 0,
     "sort" : {
-      "empty" : true,
       "sorted" : false,
-      "unsorted" : true
+      "unsorted" : true,
+      "empty" : true
     },
+    "numberOfElements" : 10,
     "first" : true,
     "last" : false,
-    "numberOfElements" : 10,
+    "size" : 10,
     "empty" : false
   },
   "error" : null
@@ -1947,26 +1947,26 @@ Content-Length: 5184
     } ],
     "pageable" : {
       "sort" : {
-        "empty" : true,
         "sorted" : false,
-        "unsorted" : true
+        "unsorted" : true,
+        "empty" : true
       },
-      "offset" : 0,
-      "pageSize" : 10,
       "pageNumber" : 0,
-      "unpaged" : false,
-      "paged" : true
+      "pageSize" : 10,
+      "offset" : 0,
+      "paged" : true,
+      "unpaged" : false
     },
-    "size" : 10,
     "number" : 0,
     "sort" : {
-      "empty" : true,
       "sorted" : false,
-      "unsorted" : true
+      "unsorted" : true,
+      "empty" : true
     },
+    "numberOfElements" : 10,
     "first" : true,
     "last" : false,
-    "numberOfElements" : 10,
+    "size" : 10,
     "empty" : false
   },
   "error" : null

--- a/src/test/java/com/donation/service/post/PostServiceTest.java
+++ b/src/test/java/com/donation/service/post/PostServiceTest.java
@@ -77,7 +77,7 @@ public class PostServiceTest {
         User user = userRepository.save(getUser());
 
         //when
-        PostSaveRespDto savePost = postService.save(request, user.getId());
+        PostSaveRespDto savePost = postService.save(request, null,user.getId());
 
         //then
         assertThat(savePost.getWrite().getTitle()).isEqualTo("title");


### PR DESCRIPTION
# 기능 추가
### 포스팅 이미지 업로드 추가
- 이미지 업로드 3가지 방향으로 구상 : 3번째를 선택하였습니다.
  1. `@RequsetParam` 에 값 전달
  2. `Base64`로 인코딩된 값 전달
  3. `@RequestPart` 를 통한 값 전달
``` java
@PostMapping
public ResponseEntity<?> save(
        @RequestParam(name = "id") Long userId,
        @RequestPart(value = "data") @Valid PostSaveReqDto postSaveReqDto,
        @RequestPart(value = "images",required = false)List<MultipartFile> image
        ){

        PostSaveRespDto post = postService.save(postSaveReqDto,image, userId);
        return new ResponseEntity<>(CommonResponse.success(post), HttpStatus.CREATED);
 }
```

- 
# 오류 수정
- 이미지 저장시 `Post` 엔티티의 `postDetailImages`에서 `NullPointException` 발생 수정
   - `@AllArgsConstructor` `@Builder` 사용시 빈값에 대한 `Null`이 인자 값으로 들어가 오류 발생
   - 생성자를 분리하고 `addPostImage` 메서드를 통해 값을 받아 오류 수정
``` java
public void addPostImage(PostDetailImage postDetailImage){
    postDetailImage.setPost(this);
    this.getPostDetailImages().add(postDetailImage);
}
```
- `S3`의 이미지 사용시 `URL`이 아닌 이미지가 다운로드 되는 현상 수정
- `objMeta.setContentType(multipartFile.getContentType());` 를 통해 contentType 지정

# 리팩토링
- 포스팅 조회 쿼리 분리 
   - `QueryDsl`을 통해 포스팅 이미지를 조인하여 가져오려 했으나 `PostDetailImageRespository`를 생성해 따로 이미지 `URL`을 가져오는 쿼리 작성
 - 로그인시 `UserID` 반환