### PR TITLE
fix: 포스트 이미지 저장 방식 변경

### DIFF
--- a/src/main/java/com/donation/common/request/post/PostSaveReqDto.java
+++ b/src/main/java/com/donation/common/request/post/PostSaveReqDto.java
@@ -10,9 +10,12 @@ import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 public class PostSaveReqDto {
+
     @NotBlank(message = "제목이 없습니다.")
     private String title;
 
@@ -24,6 +27,8 @@ public class PostSaveReqDto {
 
     @NotNull(message = "카테고리를 선택해주세요.")
     private Category category;
+
+    List<String> images = new ArrayList<>();
 
     @Builder
     public PostSaveReqDto(String title, String content, Integer amount, Category category) {

--- a/src/main/java/com/donation/service/s3/AwsS3Service.java
+++ b/src/main/java/com/donation/service/s3/AwsS3Service.java
@@ -2,6 +2,7 @@ package com.donation.service.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.donation.config.ConstConfig;
 import com.donation.exception.s3.EmptyFileException;
 import com.donation.exception.s3.FileUploadFailedException;
@@ -10,13 +11,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.UUID;
 
 
 /**
+ * @author 정우진
  * @description AWS S3 이미지 서비스
- * @author  정우진
  */
 @RequiredArgsConstructor
 @Service
@@ -41,6 +43,23 @@ public class AwsS3Service {
 
         return amazonS3.getUrl(bucket, s3FileName).toString();
     }
+
+
+    public String upload(byte[] image) {
+        ObjectMetadata objMeta = new ObjectMetadata();
+        String s3FileName = UUID.randomUUID().toString();
+
+        try {
+            objMeta.setContentLength(image.length);
+            objMeta.setContentType("image/png");
+            objMeta.setCacheControl("public, max-age=31536000");
+            amazonS3.putObject(new PutObjectRequest(bucket, s3FileName, new ByteArrayInputStream(image), objMeta));
+        } catch (Exception e) {
+            throw new FileUploadFailedException();
+        }
+        return amazonS3.getUrl(bucket, s3FileName).toString();
+    }
+
 
     private void validateFileExists(MultipartFile multipartFile) {
         if (multipartFile.isEmpty()) {

--- a/src/main/java/com/donation/web/controller/post/PostController.java
+++ b/src/main/java/com/donation/web/controller/post/PostController.java
@@ -7,6 +7,7 @@ import com.donation.common.response.post.PostFindRespDto;
 import com.donation.common.response.post.PostListRespDto;
 import com.donation.common.response.post.PostSaveRespDto;
 import com.donation.service.post.PostService;
+import com.donation.service.s3.AwsS3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -14,10 +15,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
-import java.util.List;
 
 import static com.donation.domain.enums.PostState.APPROVAL;
 import static com.donation.domain.enums.PostState.COMPLETION;
@@ -28,15 +27,14 @@ import static com.donation.domain.enums.PostState.COMPLETION;
 @RequestMapping("/api/post")
 public class PostController {
     private final PostService postService;
+    private final AwsS3Service awsS3Service;
 
-    @PostMapping
+    @PostMapping("/{id}")
     public ResponseEntity<?> save(
-            @RequestParam(name = "id") Long userId,
-            @RequestPart(value = "data") @Valid PostSaveReqDto postSaveReqDto,
-            @RequestPart(value = "images",required = false)List<MultipartFile> image
-            ){
-
-        PostSaveRespDto post = postService.save(postSaveReqDto,image, userId);
+            @PathVariable Long id,
+            @RequestBody @Valid PostSaveReqDto postSaveReqDto
+    ){
+        PostSaveRespDto post = postService.save(postSaveReqDto, id);
         return new ResponseEntity<>(CommonResponse.success(post), HttpStatus.CREATED);
     }
 

--- a/src/main/resources/templates/docs/index.html
+++ b/src/main/resources/templates/docs/index.html
@@ -911,8 +911,8 @@ Content-Length: 1816
         "unsorted" : true
       },
       "offset" : 0,
-      "pageNumber" : 0,
       "pageSize" : 10,
+      "pageNumber" : 0,
       "unpaged" : false,
       "paged" : true
     },
@@ -1027,40 +1027,20 @@ Content-Length: 61
 <h3 id="_요청_4"><a class="link" href="#_요청_4">요청</a></h3>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/post?id=51 HTTP/1.1
-Content-Type: multipart/form-data;charset=UTF-8; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/post/51 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 110
 Host: api.springdocs.com
 
---6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Content-Disposition: form-data; name=id
-
-51
---6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Content-Disposition: form-data; name=data; filename=data
-Content-Type: application/json
-
-{"title":"title","content":"content","amount":1,"category":"ETC"}
---6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
+{
+  "title" : "title",
+  "content" : "content",
+  "amount" : 1,
+  "category" : "ETC",
+  "images" : [ ]
+}</code></pre>
 </div>
 </div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">포스트 ID</p></td>
-</tr>
-</tbody>
-</table>
 </div>
 <div class="sect2">
 <h3 id="_응답_7"><a class="link" href="#_응답_7">응답</a></h3>
@@ -1213,7 +1193,7 @@ Host: api.springdocs.com</code></pre>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">유저 ID</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">포스트 ID</p></td>
 </tr>
 </tbody>
 </table>
@@ -1550,8 +1530,8 @@ Content-Length: 5177
         "unsorted" : true
       },
       "offset" : 0,
-      "pageNumber" : 0,
       "pageSize" : 10,
+      "pageNumber" : 0,
       "unpaged" : false,
       "paged" : true
     },
@@ -2056,8 +2036,8 @@ Content-Length: 5184
         "unsorted" : true
       },
       "offset" : 0,
-      "pageNumber" : 0,
       "pageSize" : 10,
+      "pageNumber" : 0,
       "unpaged" : false,
       "paged" : true
     },

--- a/src/test/java/com/donation/controller/post/PostControllerDocTest.java
+++ b/src/test/java/com/donation/controller/post/PostControllerDocTest.java
@@ -18,12 +18,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -37,8 +35,8 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -108,11 +106,10 @@ public class PostControllerDocTest {
                 .category(ETC)
                 .build();
 
-        String dtoJson = objectMapper.writeValueAsString(dto);
-        MockMultipartFile request = new MockMultipartFile("data", "data", "application/json", dtoJson.getBytes(StandardCharsets.UTF_8));
         // expected
-        mockMvc.perform(multipart("/api/post?id=" + user.getId())
-                        .file(request)
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/api/post/{id}", user.getId())
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto))
                 )
                 .andDo(print())
                 .andExpect(status().isCreated())
@@ -126,8 +123,8 @@ public class PostControllerDocTest {
                 .andDo(document("post-save",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestParameters(
-                                parameterWithName("id").description("포스트 ID")
+                        pathParameters(
+                                parameterWithName("id").description("유저 ID")
                         ),
                         responseFields(
                                 fieldWithPath("success").description("성공 여부"),
@@ -166,7 +163,7 @@ public class PostControllerDocTest {
                 .andDo(document("post-getOne",
                         preprocessResponse(prettyPrint()),
                         pathParameters(
-                                parameterWithName("id").description("유저 ID")
+                                parameterWithName("id").description("포스트 ID")
                         ),
                         responseFields(
                                 fieldWithPath("success").description("성공 여부"),

--- a/src/test/java/com/donation/controller/post/PostControllerTest.java
+++ b/src/test/java/com/donation/controller/post/PostControllerTest.java
@@ -17,11 +17,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -30,7 +28,8 @@ import static com.donation.domain.enums.Category.ETC;
 import static com.donation.domain.enums.PostState.APPROVAL;
 import static com.donation.domain.enums.PostState.WAITING;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -98,12 +97,11 @@ class PostControllerTest {
                 .category(ETC)
                 .build();
         User user = userRepository.save(getUser());
-        String dtoJson = objectMapper.writeValueAsString(dto);
-        MockMultipartFile request = new MockMultipartFile("data", "data", "application/json", dtoJson.getBytes(StandardCharsets.UTF_8));
 
         // expected
-        mockMvc.perform(multipart("/api/post?id="+user.getId())
-                        .file(request)
+        mockMvc.perform(post("/api/post/{id}", user.getId())
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto))
                 )
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value("true"))

--- a/src/test/java/com/donation/service/post/PostServiceTest.java
+++ b/src/test/java/com/donation/service/post/PostServiceTest.java
@@ -77,7 +77,7 @@ public class PostServiceTest {
         User user = userRepository.save(getUser());
 
         //when
-        PostSaveRespDto savePost = postService.save(request, null,user.getId());
+        PostSaveRespDto savePost = postService.save(request,user.getId());
 
         //then
         assertThat(savePost.getWrite().getTitle()).isEqualTo("title");


### PR DESCRIPTION
# 변경 사항
### 기존 방식
- `Controller` -> `@RequestPart`로 `MultipartFile`을 전달받아 `S3`에 저장하는 방식을 사용
### 변경
- `Controller` -> `PostSaveReqDto`에 `List<String> images`를 통해 `Base64`의 값을 전달받아 저장하는 방식으로 수정
### 변경 이유 
- 프론트엔드 개발자의 수정 요청으로인한 변경처리


### Base64 사용방식
- `Base64`로 인코딩된 값이 `List<String> images`로 저장 
- `images`를 `byte[]`로 변경
``` java
private void addPostDetailImage(List<String> images, Post post) {
    for (String image : images) {
        if (image.isEmpty())
            continue;

        byte[] imageDecode = Base64.getMimeDecoder().decode(image.substring(image.indexOf(",") + 1));
        post.addPostImage(PostDetailImage.of(awsS3Service.upload(imageDecode)));
    }
}
```
- `byte[]`를 `S3`에 저장
```java
public String upload(byte[] image) {
    ObjectMetadata objMeta = new ObjectMetadata();
    String s3FileName = UUID.randomUUID().toString();

    try {
        objMeta.setContentLength(image.length);
        objMeta.setContentType("image/png");
        objMeta.setCacheControl("public, max-age=31536000");
        amazonS3.putObject(new PutObjectRequest(bucket, s3FileName, new ByteArrayInputStream(image), objMeta));
    } catch (Exception e) {
        throw new FileUploadFailedException();
    }
    return amazonS3.getUrl(bucket, s3FileName).toString();
}
```
