### PR TITLE
feat: 댓글 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bin/
 
 ## config
 application-prod.yml
+application-dev.yml
 application-s3.yml
 src/main/java/com/donation/init.java
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -149,3 +149,32 @@ include::{snippets}/favorite-list/request-parameters.adoc[]
 === 응답
 include::{snippets}/favorite-list/http-response.adoc[]
 
+= Comment API
+== 댓글 요청
+=== 요청
+include::{snippets}/comment-save/http-request.adoc[]
+include::{snippets}/comment-save/path-parameters.adoc[]
+=== 응답
+include::{snippets}/comment-save/http-response.adoc[]
+
+== 대댓글 요청
+=== 요청
+include::{snippets}/reply-save/http-request.adoc[]
+include::{snippets}/reply-save/path-parameters.adoc[]
+=== 응답
+include::{snippets}/reply-save/http-response.adoc[]
+
+= 댓글 삭제 요청
+=== 요청
+include::{snippets}/comment-delete/http-request.adoc[]
+include::{snippets}/comment-delete/path-parameters.adoc[]
+=== 응답
+include::{snippets}/comment-delete/http-response.adoc[]
+
+== 댓글 리스트 요청
+=== 요청
+include::{snippets}/comment-getList/http-request.adoc[]
+include::{snippets}/comment-getList/path-parameters.adoc[]
+=== 응답
+include::{snippets}/comment-getList/http-response.adoc[]
+include::{snippets}/comment-getList/response-fields.adoc[]

--- a/src/main/java/com/donation/common/request/comment/CommentSaveReqDto.java
+++ b/src/main/java/com/donation/common/request/comment/CommentSaveReqDto.java
@@ -1,0 +1,20 @@
+package com.donation.common.request.comment;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+public class CommentSaveReqDto {
+
+    @NotBlank(message = "댓글은 1자 이상 100자 이하여야 합니다.")
+    String message;
+
+    @Builder
+    public CommentSaveReqDto(final String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/donation/common/response/comment/CommentResponse.java
+++ b/src/main/java/com/donation/common/response/comment/CommentResponse.java
@@ -1,0 +1,42 @@
+package com.donation.common.response.comment;
+
+import com.donation.domain.entites.Comment;
+import com.donation.domain.entites.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CommentResponse {
+    private Long id;
+    private String name;
+    private String profileImage;
+    private String content;
+    private LocalDateTime createdAt;
+    private List<ReplyResponse> replies;
+
+    @Builder
+    public CommentResponse(final Long id,final String name,final String profileImage,final String content,final LocalDateTime createdAt, final List<ReplyResponse> replies) {
+        this.id = id;
+        this.name = name;
+        this.profileImage = profileImage;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.replies = replies;
+    }
+
+    public static CommentResponse of(final Comment comment, final User user, List<ReplyResponse> replies){
+        return CommentResponse.builder()
+                .id(comment.getId())
+                .name(user.getName())
+                .profileImage(user.getProfileImage())
+                .content(comment.getMessage().getValue())
+                .createdAt(comment.getCreateAt())
+                .replies(replies)
+                .build();
+    }
+}

--- a/src/main/java/com/donation/common/response/comment/CommentResponse.java
+++ b/src/main/java/com/donation/common/response/comment/CommentResponse.java
@@ -12,20 +12,26 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class CommentResponse {
+
+    private static final String DELETE_COMMENT_MESSAGE = "삭제된 댓글 입니다.";
+    private static final String DELETE_COMMENT_NAME = "USER";
+
     private Long id;
     private String name;
     private String profileImage;
     private String content;
     private LocalDateTime createdAt;
+    private boolean doesExist;
     private List<ReplyResponse> replies;
 
     @Builder
-    public CommentResponse(final Long id,final String name,final String profileImage,final String content,final LocalDateTime createdAt, final List<ReplyResponse> replies) {
+    public CommentResponse(final Long id,final String name,final String profileImage,final String content,final LocalDateTime createdAt, final boolean doesExist, final List<ReplyResponse> replies) {
         this.id = id;
         this.name = name;
         this.profileImage = profileImage;
         this.content = content;
         this.createdAt = createdAt;
+        this.doesExist = doesExist;
         this.replies = replies;
     }
 
@@ -36,6 +42,18 @@ public class CommentResponse {
                 .profileImage(user.getProfileImage())
                 .content(comment.getMessage().getValue())
                 .createdAt(comment.getCreateAt())
+                .doesExist(true)
+                .replies(replies)
+                .build();
+    }
+
+    public static CommentResponse of(final Comment comment, List<ReplyResponse> replies){
+        return CommentResponse.builder()
+                .id(comment.getId())
+                .name(DELETE_COMMENT_NAME)
+                .content(DELETE_COMMENT_MESSAGE)
+                .createdAt(comment.getCreateAt())
+                .doesExist(false)
                 .replies(replies)
                 .build();
     }

--- a/src/main/java/com/donation/common/response/comment/ReplyResponse.java
+++ b/src/main/java/com/donation/common/response/comment/ReplyResponse.java
@@ -1,0 +1,39 @@
+package com.donation.common.response.comment;
+
+import com.donation.domain.entites.Comment;
+import com.donation.domain.entites.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class ReplyResponse {
+
+    private Long id;
+    private String name;
+    private String profileImage;
+    private String content;
+    private LocalDateTime createdAt;
+
+    @Builder
+    public ReplyResponse(final Long id, final String name,final String profileImage,final String content,final LocalDateTime createdAt) {
+        this.id = id;
+        this.name = name;
+        this.profileImage = profileImage;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
+
+    public static ReplyResponse of(Comment comment, User user){
+        return ReplyResponse.builder()
+                .id(comment.getId())
+                .name(user.getName())
+                .profileImage(user.getProfileImage())
+                .content(comment.getMessage().getValue())
+                .createdAt(comment.getCreateAt())
+                .build();
+    }
+}

--- a/src/main/java/com/donation/domain/embed/Message.java
+++ b/src/main/java/com/donation/domain/embed/Message.java
@@ -17,7 +17,7 @@ public class Message {
 
     private static final int MAX_MESSAGE_LENGTH = 100;
 
-    @Column(name = "massage", nullable = false)
+    @Column(name = "message", nullable = false)
     private String value;
 
     @Builder

--- a/src/main/java/com/donation/domain/embed/Message.java
+++ b/src/main/java/com/donation/domain/embed/Message.java
@@ -1,0 +1,37 @@
+package com.donation.domain.embed;
+
+import com.donation.exception.DonationInvalidateException;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = PROTECTED)
+public class Message {
+
+    private static final int MAX_MESSAGE_LENGTH = 100;
+
+    @Column(name = "massage", nullable = false)
+    private String value;
+
+    @Builder
+    public Message(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(String value){
+        if (value == null || value.isBlank()) {
+            throw new DonationInvalidateException("댓글의 내용이 존재하지 않습니다.");
+        }
+        if (value.length() > MAX_MESSAGE_LENGTH){
+            throw new DonationInvalidateException("댓글의 길이가 제한을 초과합니다.");
+        }
+    }
+}

--- a/src/main/java/com/donation/domain/entites/Comment.java
+++ b/src/main/java/com/donation/domain/entites/Comment.java
@@ -1,6 +1,7 @@
 package com.donation.domain.entites;
 
 import com.donation.domain.embed.Message;
+import com.donation.exception.DonationInvalidateException;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -41,6 +42,8 @@ public class Comment extends BaseEntity{
     @Embedded
     private Message message;
 
+    private boolean softRemoved;
+
     @Builder
     public Comment(User user, Post post, String message, Comment parent) {
         this.user = user;
@@ -59,6 +62,12 @@ public class Comment extends BaseEntity{
         return child;
     }
 
+    public void validateOwner(Long useId) {
+        if (!useId.equals(user.getId())) {
+            throw new DonationInvalidateException("댓글의 작성자만 삭제할 수 있습니다.");
+        }
+    }
+
     public void deleteChild(Comment reply) {
         children.remove(reply);
     }
@@ -69,5 +78,9 @@ public class Comment extends BaseEntity{
 
     public boolean hasNoReply() {
         return children.isEmpty();
+    }
+
+    public void changePretendingToBeRemoved() {
+        this.softRemoved = true;
     }
 }

--- a/src/main/java/com/donation/domain/entites/Comment.java
+++ b/src/main/java/com/donation/domain/entites/Comment.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -55,5 +56,17 @@ public class Comment extends BaseEntity{
         Comment child = new Comment(user, post, message, parent);
         parent.getChildren().add(child);
         return child;
+    }
+
+    public void deleteChild(Comment reply) {
+        children.remove(reply);
+    }
+
+    public boolean isParent() {
+        return Objects.isNull(parent);
+    }
+
+    public boolean hasNoReply() {
+        return children.isEmpty();
     }
 }

--- a/src/main/java/com/donation/domain/entites/Comment.java
+++ b/src/main/java/com/donation/domain/entites/Comment.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static javax.persistence.CascadeType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -26,7 +27,7 @@ public class Comment extends BaseEntity{
     @JoinColumn(name = "parent_id")
     private Comment parent;
 
-    @OneToMany(mappedBy = "parent")
+    @OneToMany(mappedBy = "parent", cascade = ALL)
     private List<Comment> children = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/donation/domain/entites/Comment.java
+++ b/src/main/java/com/donation/domain/entites/Comment.java
@@ -1,0 +1,59 @@
+package com.donation.domain.entites;
+
+import com.donation.domain.embed.Message;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Table(name = "comment")
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Comment extends BaseEntity{
+
+    @Id @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent")
+    private List<Comment> children = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Embedded
+    private Message message;
+
+    @Builder
+    public Comment(User user, Post post, String message, Comment parent) {
+        this.user = user;
+        this.post = post;
+        this.message = new Message(message);
+        this.parent = parent;
+    }
+
+    public static Comment parent(User user, Post post, String message) {
+        return new Comment(user, post, message, null);
+    }
+
+    public static Comment child(User user, Post post, String message, Comment parent) {
+        Comment child = new Comment(user, post, message, parent);
+        parent.getChildren().add(child);
+        return child;
+    }
+}

--- a/src/main/java/com/donation/exception/DonationInvalidateException.java
+++ b/src/main/java/com/donation/exception/DonationInvalidateException.java
@@ -7,6 +7,7 @@ public class DonationInvalidateException extends DonationException{
     public DonationInvalidateException(final String message) {
         super(message);
     }
+
     @Override
     public HttpStatus statusCode() {
         return HttpStatus.BAD_REQUEST;

--- a/src/main/java/com/donation/repository/comment/CommentRepository.java
+++ b/src/main/java/com/donation/repository/comment/CommentRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @EntityGraph(attributePaths = {"user"})
-    List<Comment> findCommentByPostAndParentIsNull(final Post post);
+    List<Comment> findCommentByPostIdAndParentIsNull(final Long postId);
 
     @EntityGraph(attributePaths = {"user"})
     List<Comment> findRepliesByParent(final Comment parent);

--- a/src/main/java/com/donation/repository/comment/CommentRepository.java
+++ b/src/main/java/com/donation/repository/comment/CommentRepository.java
@@ -11,18 +11,23 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @EntityGraph(attributePaths = {"user"})
-    List<Comment> findCommentByPostAndParentIsNull(Post post);
+    List<Comment> findCommentByPostAndParentIsNull(final Post post);
 
     @EntityGraph(attributePaths = {"user"})
-    List<Comment> findRepliesByParent(Comment parent);
+    List<Comment> findRepliesByParent(final Comment parent);
 
     boolean existsById(final Long id);
 
-    void deleteByPost(Post post);
+    void deleteByPost(final Post post);
 
     default void validateExistsById(final Long id){
         if (!existsById(id)){
             throw new DonationNotFoundException("존재하지 않는 댓글입니다.");
         }
+    }
+
+    default Comment getById(final Long id){
+        return findById(id)
+                .orElseThrow(() -> new DonationNotFoundException("존재하지 않는 댓글입니다."));
     }
 }

--- a/src/main/java/com/donation/repository/comment/CommentRepository.java
+++ b/src/main/java/com/donation/repository/comment/CommentRepository.java
@@ -1,0 +1,28 @@
+package com.donation.repository.comment;
+
+import com.donation.domain.entites.Comment;
+import com.donation.domain.entites.Post;
+import com.donation.exception.DonationNotFoundException;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @EntityGraph(attributePaths = {"user"})
+    List<Comment> findCommentByPostAndParentIsNull(Post post);
+
+    @EntityGraph(attributePaths = {"user"})
+    List<Comment> findRepliesByParent(Comment parent);
+
+    boolean existsById(final Long id);
+
+    void deleteByPost(Post post);
+
+    default void validateExistsById(final Long id){
+        if (!existsById(id)){
+            throw new DonationNotFoundException("존재하지 않는 댓글입니다.");
+        }
+    }
+}

--- a/src/main/java/com/donation/service/comment/CommentService.java
+++ b/src/main/java/com/donation/service/comment/CommentService.java
@@ -48,12 +48,14 @@ public class CommentService {
 
     public List<CommentResponse> findComment(final Long postId){
         return commentRepository.findCommentByPostIdAndParentIsNull(postId).stream()
-                .filter(comment -> !comment.isSoftRemoved())
                 .map(this::convertToCommentResponse)
                 .collect(Collectors.toList());
     }
 
     public CommentResponse convertToCommentResponse(Comment comment){
+        if(comment.isSoftRemoved()){
+            return CommentResponse.of(comment, convertToRepliesResponse(comment));
+        }
         return CommentResponse.of(comment, comment.getUser(), convertToRepliesResponse(comment));
     }
 
@@ -70,7 +72,7 @@ public class CommentService {
         deleteDelegate(comment);
     }
 
-    public void deleteDelegate(Comment comment){
+    private void deleteDelegate(Comment comment){
         if(comment.isParent()){
             deleteParent(comment);
             return;

--- a/src/main/java/com/donation/service/comment/CommentService.java
+++ b/src/main/java/com/donation/service/comment/CommentService.java
@@ -73,6 +73,7 @@ public class CommentService {
     public void deleteDelegate(Comment comment){
         if(comment.isParent()){
             deleteParent(comment);
+            return;
         }
         deleteChild(comment);
     }

--- a/src/main/java/com/donation/service/comment/CommentService.java
+++ b/src/main/java/com/donation/service/comment/CommentService.java
@@ -1,0 +1,42 @@
+package com.donation.service.comment;
+
+import com.donation.common.request.comment.CommentSaveReqDto;
+import com.donation.domain.entites.Comment;
+import com.donation.domain.entites.Post;
+import com.donation.domain.entites.User;
+import com.donation.repository.comment.CommentRepository;
+import com.donation.repository.post.PostRepository;
+import com.donation.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public Long saveComment(final Long postId,final Long userId, final CommentSaveReqDto commentSaveReqDto){
+        Post post = postRepository.getById(postId);
+        User user = userRepository.getById(userId);
+        Comment comment = Comment.parent(user, post, commentSaveReqDto.getMessage());
+        return commentRepository.save(comment).getId();
+    }
+
+//    @Transactional
+//    public Long saveReply(){
+//        Comment parent = commentRepository.getById(1L);
+//        User user = userRepository.getById(1L);
+//        if (!parent.isParent())
+//            throw new DonationInvalidateException("대댓글에는 답글을 달 수 없습니다.");
+//        Comment child = Comment.child(user, parent.getPost(), "", parent);
+//        return commentRepository.save(child).getId();
+//    }
+
+
+}

--- a/src/main/java/com/donation/service/comment/CommentService.java
+++ b/src/main/java/com/donation/service/comment/CommentService.java
@@ -4,6 +4,7 @@ import com.donation.common.request.comment.CommentSaveReqDto;
 import com.donation.domain.entites.Comment;
 import com.donation.domain.entites.Post;
 import com.donation.domain.entites.User;
+import com.donation.exception.DonationInvalidateException;
 import com.donation.repository.comment.CommentRepository;
 import com.donation.repository.post.PostRepository;
 import com.donation.repository.user.UserRepository;
@@ -28,15 +29,14 @@ public class CommentService {
         return commentRepository.save(comment).getId();
     }
 
-//    @Transactional
-//    public Long saveReply(){
-//        Comment parent = commentRepository.getById(1L);
-//        User user = userRepository.getById(1L);
-//        if (!parent.isParent())
-//            throw new DonationInvalidateException("대댓글에는 답글을 달 수 없습니다.");
-//        Comment child = Comment.child(user, parent.getPost(), "", parent);
-//        return commentRepository.save(child).getId();
-//    }
-
+    @Transactional
+    public Long saveReply(final Long commentId, final Long userId, final CommentSaveReqDto commentSaveReqDto){
+        Comment parent = commentRepository.getById(commentId);
+        User user = userRepository.getById(userId);
+        if (!parent.isParent())
+            throw new DonationInvalidateException("대댓글에는 답글을 달 수 없습니다.");
+        Comment child = Comment.child(user, parent.getPost(), commentSaveReqDto.getMessage(), parent);
+        return commentRepository.save(child).getId();
+    }
 
 }

--- a/src/main/java/com/donation/service/post/PostService.java
+++ b/src/main/java/com/donation/service/post/PostService.java
@@ -9,6 +9,7 @@ import com.donation.domain.entites.Post;
 import com.donation.domain.entites.PostDetailImage;
 import com.donation.domain.entites.User;
 import com.donation.domain.enums.PostState;
+import com.donation.repository.comment.CommentRepository;
 import com.donation.repository.post.PostRepository;
 import com.donation.repository.user.UserRepository;
 import com.donation.repository.utils.PageCustom;
@@ -26,6 +27,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final AwsS3Service awsS3Service;
+    private final CommentRepository commentRepository;
 
     public PostSaveRespDto createPost(PostSaveReqDto postSaveReqDto, Long userId) {
         User user = userRepository.getById(userId);
@@ -53,7 +55,9 @@ public class PostService {
     }
 
     public void delete(Long postId) {
-        postRepository.delete(postRepository.getById(postId));
+        Post post = postRepository.getById(postId);
+        postRepository.delete(post);
+        commentRepository.deleteByPost(post);
     }
 
     public PageCustom<PostListRespDto> getList(Pageable pageable, PostState... states) {

--- a/src/main/java/com/donation/web/controller/comment/CommentController.java
+++ b/src/main/java/com/donation/web/controller/comment/CommentController.java
@@ -1,0 +1,50 @@
+package com.donation.web.controller.comment;
+
+import com.donation.common.CommonResponse;
+import com.donation.common.request.comment.CommentSaveReqDto;
+import com.donation.common.response.comment.CommentResponse;
+import com.donation.service.comment.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/post/{id}/comment/{userId}")
+    public ResponseEntity<?> addComment(@PathVariable(name = "id") Long postId,
+                                        @RequestBody @Valid CommentSaveReqDto commentSaveReqDto,
+                                        @PathVariable Long userId){
+        Long commentId = commentService.saveComment(postId, userId, commentSaveReqDto);
+        return new ResponseEntity<>(CommonResponse.success(commentId), HttpStatus.CREATED);
+    }
+
+    @PostMapping("/comment/{id}/reply/{userId}")
+    public ResponseEntity<?> addReply(@PathVariable(name = "id") Long postId,
+                                        @RequestBody @Valid CommentSaveReqDto commentSaveReqDto,
+                                        @PathVariable Long userId){
+        Long commentId = commentService.saveReply(postId, userId, commentSaveReqDto);
+        return new ResponseEntity<>(CommonResponse.success(commentId), HttpStatus.CREATED);
+    }
+
+    @GetMapping("/post/{id}/comment")
+    public ResponseEntity<?> findComments(@PathVariable(name = "id") Long postId){
+        List<CommentResponse> comment = commentService.findComment(postId);
+        return new ResponseEntity<>(CommonResponse.success(comment), HttpStatus.CREATED);
+    }
+
+    @DeleteMapping("/comment/{id}/{userId}")
+    public ResponseEntity<?> deleteComment(@PathVariable Long id, @PathVariable Long userId){
+        commentService.delete(id,userId);
+        return new ResponseEntity<>(CommonResponse.success(), HttpStatus.CREATED);
+    }
+
+}

--- a/src/main/java/com/donation/web/controller/comment/CommentController.java
+++ b/src/main/java/com/donation/web/controller/comment/CommentController.java
@@ -23,28 +23,28 @@ public class CommentController {
     public ResponseEntity<?> addComment(@PathVariable(name = "id") Long postId,
                                         @RequestBody @Valid CommentSaveReqDto commentSaveReqDto,
                                         @PathVariable Long userId){
-        Long commentId = commentService.saveComment(postId, userId, commentSaveReqDto);
-        return new ResponseEntity<>(CommonResponse.success(commentId), HttpStatus.CREATED);
+        commentService.saveComment(postId, userId, commentSaveReqDto);
+        return new ResponseEntity<>(CommonResponse.success(), HttpStatus.CREATED);
     }
 
     @PostMapping("/comment/{id}/reply/{userId}")
     public ResponseEntity<?> addReply(@PathVariable(name = "id") Long postId,
                                         @RequestBody @Valid CommentSaveReqDto commentSaveReqDto,
                                         @PathVariable Long userId){
-        Long commentId = commentService.saveReply(postId, userId, commentSaveReqDto);
-        return new ResponseEntity<>(CommonResponse.success(commentId), HttpStatus.CREATED);
+        commentService.saveReply(postId, userId, commentSaveReqDto);
+        return new ResponseEntity<>(CommonResponse.success(), HttpStatus.CREATED);
     }
 
     @GetMapping("/post/{id}/comment")
     public ResponseEntity<?> findComments(@PathVariable(name = "id") Long postId){
         List<CommentResponse> comment = commentService.findComment(postId);
-        return new ResponseEntity<>(CommonResponse.success(comment), HttpStatus.CREATED);
+        return ResponseEntity.ok(CommonResponse.success(comment));
     }
 
     @DeleteMapping("/comment/{id}/{userId}")
     public ResponseEntity<?> deleteComment(@PathVariable Long id, @PathVariable Long userId){
         commentService.delete(id,userId);
-        return new ResponseEntity<>(CommonResponse.success(), HttpStatus.CREATED);
+        return ResponseEntity.ok(CommonResponse.success());
     }
 
 }

--- a/src/main/resources/db/migration/V003__Create_comment.sql
+++ b/src/main/resources/db/migration/V003__Create_comment.sql
@@ -1,0 +1,17 @@
+CREATE TABLE if not exists comment
+(
+    comment_id      bigint PRIMARY KEY AUTO_INCREMENT,
+    user_id   bigint,
+    post_id        bigint,
+    message      varchar(255),
+    soft_removed bit(1),
+    parent_id    bigint,
+    create_at    timestamp,
+    update_at    timestamp
+) engine = InnoDB;
+
+ALTER TABLE comment
+    ADD FOREIGN KEY (user_id) REFERENCES users (user_id);
+
+ALTER TABLE comment
+    ADD FOREIGN KEY (post_id) REFERENCES post (post_id);

--- a/src/main/resources/templates/docs/index.html
+++ b/src/main/resources/templates/docs/index.html
@@ -1996,7 +1996,7 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: SAMEORIGIN
-Content-Length: 6081
+Content-Length: 6085
 
 {
   "success" : true,
@@ -2008,7 +2008,7 @@ Content-Length: 6081
       "amount" : "10.11",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.779861",
+      "localDateTime" : "2022-10-31T15:56:04.985895",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2018,7 +2018,7 @@ Content-Length: 6081
       "amount" : "10.12",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.785879",
+      "localDateTime" : "2022-10-31T15:56:04.991035",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2028,7 +2028,7 @@ Content-Length: 6081
       "amount" : "10.13",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.787862",
+      "localDateTime" : "2022-10-31T15:56:04.992034",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2038,7 +2038,7 @@ Content-Length: 6081
       "amount" : "10.14",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.788864",
+      "localDateTime" : "2022-10-31T15:56:04.993037",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2048,7 +2048,7 @@ Content-Length: 6081
       "amount" : "10.15",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.790864",
+      "localDateTime" : "2022-10-31T15:56:04.995038",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2058,7 +2058,7 @@ Content-Length: 6081
       "amount" : "10.16",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.791864",
+      "localDateTime" : "2022-10-31T15:56:04.996035",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2068,7 +2068,7 @@ Content-Length: 6081
       "amount" : "10.17",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.793862",
+      "localDateTime" : "2022-10-31T15:56:04.998036",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2078,7 +2078,7 @@ Content-Length: 6081
       "amount" : "10.18",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.794863",
+      "localDateTime" : "2022-10-31T15:56:04.999036",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2088,7 +2088,7 @@ Content-Length: 6081
       "amount" : "10.19",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.79655",
+      "localDateTime" : "2022-10-31T15:56:05.001035",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2098,7 +2098,7 @@ Content-Length: 6081
       "amount" : "10.110",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.798569",
+      "localDateTime" : "2022-10-31T15:56:05.002036",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2108,7 +2108,7 @@ Content-Length: 6081
       "amount" : "10.111",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.799573",
+      "localDateTime" : "2022-10-31T15:56:05.004121",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2118,7 +2118,7 @@ Content-Length: 6081
       "amount" : "10.112",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.800572",
+      "localDateTime" : "2022-10-31T15:56:05.005316",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2128,7 +2128,7 @@ Content-Length: 6081
       "amount" : "10.113",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.802571",
+      "localDateTime" : "2022-10-31T15:56:05.006314",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2138,7 +2138,7 @@ Content-Length: 6081
       "amount" : "10.114",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.80357",
+      "localDateTime" : "2022-10-31T15:56:05.007315",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2148,7 +2148,7 @@ Content-Length: 6081
       "amount" : "10.115",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.80457",
+      "localDateTime" : "2022-10-31T15:56:05.008314",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2158,7 +2158,7 @@ Content-Length: 6081
       "amount" : "10.116",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.80657",
+      "localDateTime" : "2022-10-31T15:56:05.010319",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2168,7 +2168,7 @@ Content-Length: 6081
       "amount" : "10.117",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.808568",
+      "localDateTime" : "2022-10-31T15:56:05.011316",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2178,7 +2178,7 @@ Content-Length: 6081
       "amount" : "10.118",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.809569",
+      "localDateTime" : "2022-10-31T15:56:05.013314",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2188,7 +2188,7 @@ Content-Length: 6081
       "amount" : "10.119",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.811569",
+      "localDateTime" : "2022-10-31T15:56:05.015318",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2198,32 +2198,32 @@ Content-Length: 6081
       "amount" : "10.120",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:41:40.813575",
+      "localDateTime" : "2022-10-31T15:56:05.016315",
       "total" : "202.615",
       "category" : "ETC"
     } ],
     "pageable" : {
       "sort" : {
-        "empty" : true,
         "sorted" : false,
-        "unsorted" : true
+        "unsorted" : true,
+        "empty" : true
       },
-      "offset" : 0,
       "pageSize" : 20,
       "pageNumber" : 0,
+      "offset" : 0,
       "unpaged" : false,
       "paged" : true
     },
-    "size" : 20,
     "number" : 0,
     "sort" : {
-      "empty" : true,
       "sorted" : false,
-      "unsorted" : true
+      "unsorted" : true,
+      "empty" : true
     },
     "numberOfElements" : 20,
     "first" : true,
     "last" : true,
+    "size" : 20,
     "empty" : false
   },
   "error" : null
@@ -2280,7 +2280,7 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: SAMEORIGIN
-Content-Length: 5448
+Content-Length: 5444
 
 {
   "success" : true,
@@ -2290,210 +2290,210 @@ Content-Length: 5448
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.104651"
+    "localDateTime" : "2022-10-31T15:56:05.268513"
   }, {
     "title" : "title",
     "amount" : "10.12",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.10565"
+    "localDateTime" : "2022-10-31T15:56:05.26951"
   }, {
     "title" : "title",
     "amount" : "10.13",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.10665"
+    "localDateTime" : "2022-10-31T15:56:05.270508"
   }, {
     "title" : "title",
     "amount" : "10.14",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.107652"
+    "localDateTime" : "2022-10-31T15:56:05.271511"
   }, {
     "title" : "title",
     "amount" : "10.15",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.107652"
+    "localDateTime" : "2022-10-31T15:56:05.27251"
   }, {
     "title" : "title",
     "amount" : "10.16",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.108658"
+    "localDateTime" : "2022-10-31T15:56:05.27251"
   }, {
     "title" : "title",
     "amount" : "10.17",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.109652"
+    "localDateTime" : "2022-10-31T15:56:05.273509"
   }, {
     "title" : "title",
     "amount" : "10.18",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.109652"
+    "localDateTime" : "2022-10-31T15:56:05.274509"
   }, {
     "title" : "title",
     "amount" : "10.19",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.110651"
+    "localDateTime" : "2022-10-31T15:56:05.274509"
   }, {
     "title" : "title",
     "amount" : "10.110",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.110651"
+    "localDateTime" : "2022-10-31T15:56:05.275511"
   }, {
     "title" : "title",
     "amount" : "10.111",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.111651"
+    "localDateTime" : "2022-10-31T15:56:05.276509"
   }, {
     "title" : "title",
     "amount" : "10.112",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.111651"
+    "localDateTime" : "2022-10-31T15:56:05.276509"
   }, {
     "title" : "title",
     "amount" : "10.113",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.112652"
+    "localDateTime" : "2022-10-31T15:56:05.277512"
   }, {
     "title" : "title",
     "amount" : "10.114",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.113755"
+    "localDateTime" : "2022-10-31T15:56:05.278511"
   }, {
     "title" : "title",
     "amount" : "10.115",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.114796"
+    "localDateTime" : "2022-10-31T15:56:05.279509"
   }, {
     "title" : "title",
     "amount" : "10.116",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.114796"
+    "localDateTime" : "2022-10-31T15:56:05.279509"
   }, {
     "title" : "title",
     "amount" : "10.117",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.115793"
+    "localDateTime" : "2022-10-31T15:56:05.280511"
   }, {
     "title" : "title",
     "amount" : "10.118",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.115793"
+    "localDateTime" : "2022-10-31T15:56:05.28151"
   }, {
     "title" : "title",
     "amount" : "10.119",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.116794"
+    "localDateTime" : "2022-10-31T15:56:05.28251"
   }, {
     "title" : "title",
     "amount" : "10.120",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.117792"
+    "localDateTime" : "2022-10-31T15:56:05.28351"
   }, {
     "title" : "title",
     "amount" : "10.121",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.118792"
+    "localDateTime" : "2022-10-31T15:56:05.284509"
   }, {
     "title" : "title",
     "amount" : "10.122",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.119794"
+    "localDateTime" : "2022-10-31T15:56:05.285512"
   }, {
     "title" : "title",
     "amount" : "10.123",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.120796"
+    "localDateTime" : "2022-10-31T15:56:05.286511"
   }, {
     "title" : "title",
     "amount" : "10.124",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.121793"
+    "localDateTime" : "2022-10-31T15:56:05.287511"
   }, {
     "title" : "title",
     "amount" : "10.125",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.121793"
+    "localDateTime" : "2022-10-31T15:56:05.288511"
   }, {
     "title" : "title",
     "amount" : "10.126",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.122793"
+    "localDateTime" : "2022-10-31T15:56:05.289604"
   }, {
     "title" : "title",
     "amount" : "10.127",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.123793"
+    "localDateTime" : "2022-10-31T15:56:05.290613"
   }, {
     "title" : "title",
     "amount" : "10.128",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.124793"
+    "localDateTime" : "2022-10-31T15:56:05.291612"
   }, {
     "title" : "title",
     "amount" : "10.129",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.124793"
+    "localDateTime" : "2022-10-31T15:56:05.291612"
   }, {
     "title" : "title",
     "amount" : "10.130",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:41:41.125793"
+    "localDateTime" : "2022-10-31T15:56:05.292614"
   } ],
   "error" : null
 }</code></pre>

--- a/src/main/resources/templates/docs/index.html
+++ b/src/main/resources/templates/docs/index.html
@@ -562,19 +562,19 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </li>
 <li><a href="#_favorite_api">Favorite API</a>
 <ul class="sectlevel1">
-<li><a href="#_좋아요_요청_및_취소">좋아요 요청 및 취소</a>
+<li><a href="#_좋아요_요청">좋아요 요청</a>
 <ul class="sectlevel2">
 <li><a href="#_요청_15">요청</a></li>
 <li><a href="#_응답_18">응답</a></li>
 </ul>
 </li>
-<li><a href="#_좋아요를_한_유저_정보_list">좋아요를 한 유저 정보 List</a>
+<li><a href="#_좋아요_취소">좋아요 취소</a>
 <ul class="sectlevel2">
 <li><a href="#_요청_16">요청</a></li>
 <li><a href="#_응답_19">응답</a></li>
 </ul>
 </li>
-<li><a href="#_좋아요_포스트_아이디로_삭제">좋아요 포스트 아이디로 삭제</a>
+<li><a href="#_좋아요를_한_유저_정보_list">좋아요를 한 유저 정보 List</a>
 <ul class="sectlevel2">
 <li><a href="#_요청_17">요청</a></li>
 <li><a href="#_응답_20">응답</a></li>
@@ -2008,7 +2008,7 @@ Content-Length: 6083
       "amount" : "10.11",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.782701",
+      "localDateTime" : "2022-10-30T18:49:09.311536",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2018,7 +2018,7 @@ Content-Length: 6083
       "amount" : "10.12",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.7877",
+      "localDateTime" : "2022-10-30T18:49:09.318535",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2028,7 +2028,7 @@ Content-Length: 6083
       "amount" : "10.13",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.789701",
+      "localDateTime" : "2022-10-30T18:49:09.319535",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2038,7 +2038,7 @@ Content-Length: 6083
       "amount" : "10.14",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.790702",
+      "localDateTime" : "2022-10-30T18:49:09.321535",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2048,7 +2048,7 @@ Content-Length: 6083
       "amount" : "10.15",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.791702",
+      "localDateTime" : "2022-10-30T18:49:09.323534",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2058,7 +2058,7 @@ Content-Length: 6083
       "amount" : "10.16",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.792702",
+      "localDateTime" : "2022-10-30T18:49:09.325536",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2068,7 +2068,7 @@ Content-Length: 6083
       "amount" : "10.17",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.793703",
+      "localDateTime" : "2022-10-30T18:49:09.326536",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2078,7 +2078,7 @@ Content-Length: 6083
       "amount" : "10.18",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.794702",
+      "localDateTime" : "2022-10-30T18:49:09.328224",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2088,7 +2088,7 @@ Content-Length: 6083
       "amount" : "10.19",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.796851",
+      "localDateTime" : "2022-10-30T18:49:09.331237",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2098,7 +2098,7 @@ Content-Length: 6083
       "amount" : "10.110",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.798936",
+      "localDateTime" : "2022-10-30T18:49:09.332765",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2108,7 +2108,7 @@ Content-Length: 6083
       "amount" : "10.111",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.799935",
+      "localDateTime" : "2022-10-30T18:49:09.33421",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2118,7 +2118,7 @@ Content-Length: 6083
       "amount" : "10.112",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.800935",
+      "localDateTime" : "2022-10-30T18:49:09.335792",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2128,7 +2128,7 @@ Content-Length: 6083
       "amount" : "10.113",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.802937",
+      "localDateTime" : "2022-10-30T18:49:09.336808",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2138,7 +2138,7 @@ Content-Length: 6083
       "amount" : "10.114",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.803936",
+      "localDateTime" : "2022-10-30T18:49:09.33781",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2148,7 +2148,7 @@ Content-Length: 6083
       "amount" : "10.115",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.804937",
+      "localDateTime" : "2022-10-30T18:49:09.338809",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2158,7 +2158,7 @@ Content-Length: 6083
       "amount" : "10.116",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.805935",
+      "localDateTime" : "2022-10-30T18:49:09.339808",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2168,7 +2168,7 @@ Content-Length: 6083
       "amount" : "10.117",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.806935",
+      "localDateTime" : "2022-10-30T18:49:09.340809",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2178,7 +2178,7 @@ Content-Length: 6083
       "amount" : "10.118",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.808937",
+      "localDateTime" : "2022-10-30T18:49:09.341809",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2188,7 +2188,7 @@ Content-Length: 6083
       "amount" : "10.119",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.809937",
+      "localDateTime" : "2022-10-30T18:49:09.342809",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2198,31 +2198,31 @@ Content-Length: 6083
       "amount" : "10.120",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:46:27.810936",
+      "localDateTime" : "2022-10-30T18:49:09.343808",
       "total" : "202.615",
       "category" : "ETC"
     } ],
     "pageable" : {
       "sort" : {
+        "unsorted" : true,
         "empty" : true,
-        "sorted" : false,
-        "unsorted" : true
+        "sorted" : false
       },
       "offset" : 0,
-      "pageNumber" : 0,
       "pageSize" : 20,
+      "pageNumber" : 0,
       "paged" : true,
       "unpaged" : false
     },
     "size" : 20,
     "number" : 0,
     "sort" : {
+      "unsorted" : true,
       "empty" : true,
-      "sorted" : false,
-      "unsorted" : true
+      "sorted" : false
     },
-    "first" : true,
     "last" : true,
+    "first" : true,
     "numberOfElements" : 20,
     "empty" : false
   },
@@ -2280,7 +2280,7 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: SAMEORIGIN
-Content-Length: 5447
+Content-Length: 5449
 
 {
   "success" : true,
@@ -2290,210 +2290,210 @@ Content-Length: 5447
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.086976"
+    "localDateTime" : "2022-10-30T18:49:09.635857"
   }, {
     "title" : "title",
     "amount" : "10.12",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.088974"
+    "localDateTime" : "2022-10-30T18:49:09.637857"
   }, {
     "title" : "title",
     "amount" : "10.13",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.089974"
+    "localDateTime" : "2022-10-30T18:49:09.638858"
   }, {
     "title" : "title",
     "amount" : "10.14",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.090975"
+    "localDateTime" : "2022-10-30T18:49:09.639857"
   }, {
     "title" : "title",
     "amount" : "10.15",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.091973"
+    "localDateTime" : "2022-10-30T18:49:09.639857"
   }, {
     "title" : "title",
     "amount" : "10.16",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.092974"
+    "localDateTime" : "2022-10-30T18:49:09.640857"
   }, {
     "title" : "title",
     "amount" : "10.17",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.093974"
+    "localDateTime" : "2022-10-30T18:49:09.641856"
   }, {
     "title" : "title",
     "amount" : "10.18",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.094973"
+    "localDateTime" : "2022-10-30T18:49:09.642859"
   }, {
     "title" : "title",
     "amount" : "10.19",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.096453"
+    "localDateTime" : "2022-10-30T18:49:09.643859"
   }, {
     "title" : "title",
     "amount" : "10.110",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.09747"
+    "localDateTime" : "2022-10-30T18:49:09.644857"
   }, {
     "title" : "title",
     "amount" : "10.111",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.098469"
+    "localDateTime" : "2022-10-30T18:49:09.646858"
   }, {
     "title" : "title",
     "amount" : "10.112",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.099471"
+    "localDateTime" : "2022-10-30T18:49:09.647859"
   }, {
     "title" : "title",
     "amount" : "10.113",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.100475"
+    "localDateTime" : "2022-10-30T18:49:09.648858"
   }, {
     "title" : "title",
     "amount" : "10.114",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.101488"
+    "localDateTime" : "2022-10-30T18:49:09.649938"
   }, {
     "title" : "title",
     "amount" : "10.115",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.102469"
+    "localDateTime" : "2022-10-30T18:49:09.650838"
   }, {
     "title" : "title",
     "amount" : "10.116",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.103469"
+    "localDateTime" : "2022-10-30T18:49:09.651968"
   }, {
     "title" : "title",
     "amount" : "10.117",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.104472"
+    "localDateTime" : "2022-10-30T18:49:09.652967"
   }, {
     "title" : "title",
     "amount" : "10.118",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.104472"
+    "localDateTime" : "2022-10-30T18:49:09.653966"
   }, {
     "title" : "title",
     "amount" : "10.119",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.105473"
+    "localDateTime" : "2022-10-30T18:49:09.654966"
   }, {
     "title" : "title",
     "amount" : "10.120",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.106469"
+    "localDateTime" : "2022-10-30T18:49:09.655968"
   }, {
     "title" : "title",
     "amount" : "10.121",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.10747"
+    "localDateTime" : "2022-10-30T18:49:09.656967"
   }, {
     "title" : "title",
     "amount" : "10.122",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.108469"
+    "localDateTime" : "2022-10-30T18:49:09.657967"
   }, {
     "title" : "title",
     "amount" : "10.123",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.109469"
+    "localDateTime" : "2022-10-30T18:49:09.658967"
   }, {
     "title" : "title",
     "amount" : "10.124",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.109469"
+    "localDateTime" : "2022-10-30T18:49:09.659967"
   }, {
     "title" : "title",
     "amount" : "10.125",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.110469"
+    "localDateTime" : "2022-10-30T18:49:09.660986"
   }, {
     "title" : "title",
     "amount" : "10.126",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.111469"
+    "localDateTime" : "2022-10-30T18:49:09.661968"
   }, {
     "title" : "title",
     "amount" : "10.127",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.112469"
+    "localDateTime" : "2022-10-30T18:49:09.662967"
   }, {
     "title" : "title",
     "amount" : "10.128",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.112469"
+    "localDateTime" : "2022-10-30T18:49:09.662967"
   }, {
     "title" : "title",
     "amount" : "10.129",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.113496"
+    "localDateTime" : "2022-10-30T18:49:09.66397"
   }, {
     "title" : "title",
     "amount" : "10.130",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:46:28.11447"
+    "localDateTime" : "2022-10-30T18:49:09.665967"
   } ],
   "error" : null
 }</code></pre>
@@ -2815,7 +2815,7 @@ Content-Length: 4207
 </div>
 <h1 id="_favorite_api" class="sect0"><a class="link" href="#_favorite_api">Favorite API</a></h1>
 <div class="sect1">
-<h2 id="_좋아요_요청_및_취소"><a class="link" href="#_좋아요_요청_및_취소">좋아요 요청 및 취소</a></h2>
+<h2 id="_좋아요_요청"><a class="link" href="#_좋아요_요청">좋아요 요청</a></h2>
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_요청_15"><a class="link" href="#_요청_15">요청</a></h3>
@@ -2869,37 +2869,64 @@ Content-Length: 61
 }</code></pre>
 </div>
 </div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_좋아요_취소"><a class="link" href="#_좋아요_취소">좋아요 취소</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_요청_16"><a class="link" href="#_요청_16">요청</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/favorite?type=CANCEL HTTP/1.1
+Content-Type: application/json
+Content-Length: 37
+Host: localhost:8080
+
+{
+  "userId" : 1,
+  "postId" : 1
+}</code></pre>
+</div>
+</div>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Parameter</th>
 <th class="tableblock halign-left valign-top">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>success</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">데이터</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>error</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">에러 발생시 오류 반환</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>type</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">저장 또는 취소</p></td>
 </tr>
 </tbody>
 </table>
+</div>
+<div class="sect2">
+<h3 id="_응답_19"><a class="link" href="#_응답_19">응답</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 61
+
+{
+  "success" : true,
+  "data" : null,
+  "error" : null
+}</code></pre>
+</div>
+</div>
 </div>
 </div>
 </div>
@@ -2907,7 +2934,7 @@ Content-Length: 61
 <h2 id="_좋아요를_한_유저_정보_list"><a class="link" href="#_좋아요를_한_유저_정보_list">좋아요를 한 유저 정보 List</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_요청_16"><a class="link" href="#_요청_16">요청</a></h3>
+<h3 id="_요청_17"><a class="link" href="#_요청_17">요청</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/favorite?postId=1 HTTP/1.1
@@ -2934,7 +2961,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect2">
-<h3 id="_응답_19"><a class="link" href="#_응답_19">응답</a></h3>
+<h3 id="_응답_20"><a class="link" href="#_응답_20">응답</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
@@ -3014,100 +3041,11 @@ Content-Length: 2260
 </div>
 </div>
 </div>
-<div class="sect1">
-<h2 id="_좋아요_포스트_아이디로_삭제"><a class="link" href="#_좋아요_포스트_아이디로_삭제">좋아요 포스트 아이디로 삭제</a></h2>
-<div class="sectionbody">
-<div class="sect2">
-<h3 id="_요청_17"><a class="link" href="#_요청_17">요청</a></h3>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/favorite?postId=39 HTTP/1.1
-Host: api.springdocs.com</code></pre>
-</div>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>postId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">포스팅 ID</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect2">
-<h3 id="_응답_20"><a class="link" href="#_응답_20">응답</a></h3>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-Vary: Origin
-Vary: Access-Control-Request-Method
-Vary: Access-Control-Request-Headers
-Content-Type: application/json
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Cache-Control: no-cache, no-store, max-age=0, must-revalidate
-Pragma: no-cache
-Expires: 0
-Strict-Transport-Security: max-age=31536000 ; includeSubDomains
-X-Frame-Options: SAMEORIGIN
-Content-Length: 61
-
-{
-  "success" : true,
-  "data" : null,
-  "error" : null
-}</code></pre>
-</div>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>success</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">데이터</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>error</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">에러 발생시 오류 반환</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-10-28 21:19:13 +0900
+Last updated 2022-10-30 18:48:49 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/templates/docs/index.html
+++ b/src/main/resources/templates/docs/index.html
@@ -582,6 +582,34 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </li>
 </ul>
 </li>
+<li><a href="#_comment_api">Comment API</a>
+<ul class="sectlevel1">
+<li><a href="#_댓글_요청">댓글 요청</a>
+<ul class="sectlevel2">
+<li><a href="#_요청_18">요청</a></li>
+<li><a href="#_응답_21">응답</a></li>
+</ul>
+</li>
+<li><a href="#_대댓글_요청">대댓글 요청</a>
+<ul class="sectlevel2">
+<li><a href="#_요청_19">요청</a></li>
+<li><a href="#_응답_22">응답</a></li>
+</ul>
+</li>
+</ul>
+</li>
+<li><a href="#_댓글_삭제_요청">댓글 삭제 요청</a>
+<ul class="sectlevel2">
+<li><a href="#_요청_20">요청</a></li>
+<li><a href="#_응답_23">응답</a></li>
+<li><a href="#_댓글_리스트_요청">댓글 리스트 요청</a>
+<ul class="sectlevel2">
+<li><a href="#_요청_21">요청</a></li>
+<li><a href="#_응답_24">응답</a></li>
+</ul>
+</li>
+</ul>
+</li>
 </ul>
 </div>
 </div>
@@ -1996,7 +2024,7 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: SAMEORIGIN
-Content-Length: 6082
+Content-Length: 6085
 
 {
   "success" : true,
@@ -2008,7 +2036,7 @@ Content-Length: 6082
       "amount" : "10.11",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.060687",
+      "localDateTime" : "2022-11-01T14:49:08.760068",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2018,7 +2046,7 @@ Content-Length: 6082
       "amount" : "10.12",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.064789",
+      "localDateTime" : "2022-11-01T14:49:08.764069",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2028,7 +2056,7 @@ Content-Length: 6082
       "amount" : "10.13",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.065808",
+      "localDateTime" : "2022-11-01T14:49:08.765068",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2038,7 +2066,7 @@ Content-Length: 6082
       "amount" : "10.14",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.06781",
+      "localDateTime" : "2022-11-01T14:49:08.766068",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2048,7 +2076,7 @@ Content-Length: 6082
       "amount" : "10.15",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.068809",
+      "localDateTime" : "2022-11-01T14:49:08.767067",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2058,7 +2086,7 @@ Content-Length: 6082
       "amount" : "10.16",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.069814",
+      "localDateTime" : "2022-11-01T14:49:08.768128",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2068,7 +2096,7 @@ Content-Length: 6082
       "amount" : "10.17",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.071809",
+      "localDateTime" : "2022-11-01T14:49:08.769253",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2078,7 +2106,7 @@ Content-Length: 6082
       "amount" : "10.18",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.072808",
+      "localDateTime" : "2022-11-01T14:49:08.770252",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2088,7 +2116,7 @@ Content-Length: 6082
       "amount" : "10.19",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.076146",
+      "localDateTime" : "2022-11-01T14:49:08.771252",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2098,7 +2126,7 @@ Content-Length: 6082
       "amount" : "10.110",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.07778",
+      "localDateTime" : "2022-11-01T14:49:08.773253",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2108,7 +2136,7 @@ Content-Length: 6082
       "amount" : "10.111",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.079784",
+      "localDateTime" : "2022-11-01T14:49:08.774252",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2118,7 +2146,7 @@ Content-Length: 6082
       "amount" : "10.112",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.08078",
+      "localDateTime" : "2022-11-01T14:49:08.775255",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2128,7 +2156,7 @@ Content-Length: 6082
       "amount" : "10.113",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.082779",
+      "localDateTime" : "2022-11-01T14:49:08.776256",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2138,7 +2166,7 @@ Content-Length: 6082
       "amount" : "10.114",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.083779",
+      "localDateTime" : "2022-11-01T14:49:08.777252",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2148,7 +2176,7 @@ Content-Length: 6082
       "amount" : "10.115",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.085778",
+      "localDateTime" : "2022-11-01T14:49:08.779252",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2158,7 +2186,7 @@ Content-Length: 6082
       "amount" : "10.116",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.087779",
+      "localDateTime" : "2022-11-01T14:49:08.781254",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2168,7 +2196,7 @@ Content-Length: 6082
       "amount" : "10.117",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.088776",
+      "localDateTime" : "2022-11-01T14:49:08.782253",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2178,7 +2206,7 @@ Content-Length: 6082
       "amount" : "10.118",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.090779",
+      "localDateTime" : "2022-11-01T14:49:08.784375",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2188,7 +2216,7 @@ Content-Length: 6082
       "amount" : "10.119",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.093067",
+      "localDateTime" : "2022-11-01T14:49:08.785889",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2198,7 +2226,7 @@ Content-Length: 6082
       "amount" : "10.120",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T20:09:48.094067",
+      "localDateTime" : "2022-11-01T14:49:08.787889",
       "total" : "202.615",
       "category" : "ETC"
     } ],
@@ -2211,8 +2239,8 @@ Content-Length: 6082
       "offset" : 0,
       "pageNumber" : 0,
       "pageSize" : 20,
-      "paged" : true,
-      "unpaged" : false
+      "unpaged" : false,
+      "paged" : true
     },
     "size" : 20,
     "number" : 0,
@@ -2221,9 +2249,9 @@ Content-Length: 6082
       "sorted" : false,
       "unsorted" : true
     },
+    "numberOfElements" : 20,
     "first" : true,
     "last" : true,
-    "numberOfElements" : 20,
     "empty" : false
   },
   "error" : null
@@ -2280,7 +2308,7 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: SAMEORIGIN
-Content-Length: 5448
+Content-Length: 5444
 
 {
   "success" : true,
@@ -2290,210 +2318,210 @@ Content-Length: 5448
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.427019"
+    "localDateTime" : "2022-11-01T14:49:09.024395"
   }, {
     "title" : "title",
     "amount" : "10.12",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.429019"
+    "localDateTime" : "2022-11-01T14:49:09.025382"
   }, {
     "title" : "title",
     "amount" : "10.13",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.430021"
+    "localDateTime" : "2022-11-01T14:49:09.026381"
   }, {
     "title" : "title",
     "amount" : "10.14",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.431019"
+    "localDateTime" : "2022-11-01T14:49:09.026381"
   }, {
     "title" : "title",
     "amount" : "10.15",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.433019"
+    "localDateTime" : "2022-11-01T14:49:09.027382"
   }, {
     "title" : "title",
     "amount" : "10.16",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.434019"
+    "localDateTime" : "2022-11-01T14:49:09.028442"
   }, {
     "title" : "title",
     "amount" : "10.17",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.43502"
+    "localDateTime" : "2022-11-01T14:49:09.028442"
   }, {
     "title" : "title",
     "amount" : "10.18",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.436019"
+    "localDateTime" : "2022-11-01T14:49:09.029881"
   }, {
     "title" : "title",
     "amount" : "10.19",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.438019"
+    "localDateTime" : "2022-11-01T14:49:09.030878"
   }, {
     "title" : "title",
     "amount" : "10.110",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.438893"
+    "localDateTime" : "2022-11-01T14:49:09.031878"
   }, {
     "title" : "title",
     "amount" : "10.111",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.44118"
+    "localDateTime" : "2022-11-01T14:49:09.031878"
   }, {
     "title" : "title",
     "amount" : "10.112",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.442706"
+    "localDateTime" : "2022-11-01T14:49:09.032879"
   }, {
     "title" : "title",
     "amount" : "10.113",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.444703"
+    "localDateTime" : "2022-11-01T14:49:09.033881"
   }, {
     "title" : "title",
     "amount" : "10.114",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.445704"
+    "localDateTime" : "2022-11-01T14:49:09.03488"
   }, {
     "title" : "title",
     "amount" : "10.115",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.447705"
+    "localDateTime" : "2022-11-01T14:49:09.03588"
   }, {
     "title" : "title",
     "amount" : "10.116",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.448705"
+    "localDateTime" : "2022-11-01T14:49:09.03588"
   }, {
     "title" : "title",
     "amount" : "10.117",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.449704"
+    "localDateTime" : "2022-11-01T14:49:09.036879"
   }, {
     "title" : "title",
     "amount" : "10.118",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.451703"
+    "localDateTime" : "2022-11-01T14:49:09.037879"
   }, {
     "title" : "title",
     "amount" : "10.119",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.452703"
+    "localDateTime" : "2022-11-01T14:49:09.038881"
   }, {
     "title" : "title",
     "amount" : "10.120",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.453704"
+    "localDateTime" : "2022-11-01T14:49:09.038881"
   }, {
     "title" : "title",
     "amount" : "10.121",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.454704"
+    "localDateTime" : "2022-11-01T14:49:09.039879"
   }, {
     "title" : "title",
     "amount" : "10.122",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.455789"
+    "localDateTime" : "2022-11-01T14:49:09.04088"
   }, {
     "title" : "title",
     "amount" : "10.123",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.458018"
+    "localDateTime" : "2022-11-01T14:49:09.04088"
   }, {
     "title" : "title",
     "amount" : "10.124",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.460018"
+    "localDateTime" : "2022-11-01T14:49:09.041879"
   }, {
     "title" : "title",
     "amount" : "10.125",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.461514"
+    "localDateTime" : "2022-11-01T14:49:09.04288"
   }, {
     "title" : "title",
     "amount" : "10.126",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.463033"
+    "localDateTime" : "2022-11-01T14:49:09.043943"
   }, {
     "title" : "title",
     "amount" : "10.127",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.464034"
+    "localDateTime" : "2022-11-01T14:49:09.044543"
   }, {
     "title" : "title",
     "amount" : "10.128",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.465032"
+    "localDateTime" : "2022-11-01T14:49:09.045044"
   }, {
     "title" : "title",
     "amount" : "10.129",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.466678"
+    "localDateTime" : "2022-11-01T14:49:09.046062"
   }, {
     "title" : "title",
     "amount" : "10.130",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T20:09:48.467974"
+    "localDateTime" : "2022-11-01T14:49:09.047061"
   } ],
   "error" : null
 }</code></pre>
@@ -3041,11 +3069,341 @@ Content-Length: 2260
 </div>
 </div>
 </div>
+<h1 id="_comment_api" class="sect0"><a class="link" href="#_comment_api">Comment API</a></h1>
+<div class="sect1">
+<h2 id="_댓글_요청"><a class="link" href="#_댓글_요청">댓글 요청</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_요청_18"><a class="link" href="#_요청_18">요청</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/post/1/comment/1 HTTP/1.1
+Content-Type: application/json
+Content-Length: 46
+Host: localhost:8080
+
+{
+  "message" : "일반 댓글 입니다."
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 7. /api/post/{id}/comment/{userId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">포스트 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_응답_21"><a class="link" href="#_응답_21">응답</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 201 Created
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 61
+
+{
+  "success" : true,
+  "data" : null,
+  "error" : null
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_대댓글_요청"><a class="link" href="#_대댓글_요청">대댓글 요청</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_요청_19"><a class="link" href="#_요청_19">요청</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/comment/1/reply/1 HTTP/1.1
+Content-Type: application/json
+Content-Length: 49
+Host: localhost:8080
+
+{
+  "message" : "일반 대댓글 입니다."
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 8. /api/comment/{id}/reply/{userId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_응답_22"><a class="link" href="#_응답_22">응답</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 201 Created
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 61
+
+{
+  "success" : true,
+  "data" : null,
+  "error" : null
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<h1 id="_댓글_삭제_요청" class="sect0"><a class="link" href="#_댓글_삭제_요청">댓글 삭제 요청</a></h1>
+<div class="sect2">
+<h3 id="_요청_20"><a class="link" href="#_요청_20">요청</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/comment/1/1 HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 9. /api/comment/{id}/{userId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_응답_23"><a class="link" href="#_응답_23">응답</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 61
+
+{
+  "success" : true,
+  "data" : null,
+  "error" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_댓글_리스트_요청"><a class="link" href="#_댓글_리스트_요청">댓글 리스트 요청</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_요청_21"><a class="link" href="#_요청_21">요청</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/post/1/comment HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 10. /api/post/{id}/comment</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">포스트 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_응답_24"><a class="link" href="#_응답_24">응답</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Vary: Origin
+Vary: Access-Control-Request-Method
+Vary: Access-Control-Request-Headers
+Content-Type: application/json
+Content-Length: 759
+
+{
+  "success" : true,
+  "data" : [ {
+    "id" : null,
+    "name" : "일반 사용자",
+    "profileImage" : "https://avatars.githubusercontent.com/u/106054507?v=4",
+    "content" : "일반 댓글 입니다.",
+    "createdAt" : null,
+    "doesExist" : true,
+    "replies" : [ {
+      "id" : null,
+      "name" : "일반 사용자",
+      "profileImage" : "https://avatars.githubusercontent.com/u/106054507?v=4",
+      "content" : "일반 대댓글 입니다.",
+      "createdAt" : null
+    }, {
+      "id" : null,
+      "name" : "일반 사용자",
+      "profileImage" : "https://avatars.githubusercontent.com/u/106054507?v=4",
+      "content" : "일반 대댓글 입니다.",
+      "createdAt" : null
+    } ]
+  } ],
+  "error" : null
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>success</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[0].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[0].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[0].profileImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 프로필 이미지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[0].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[0].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 생성일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[0].doesExist</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 삭제 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[0].replies[0].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[0].replies[0].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[0].replies[0].profileImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원 프로필 이미지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[0].replies[0].content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[0].replies[0].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대댓글 생성일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>error</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 발생시 오류 반환</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-10-30 18:51:14 +0900
+Last updated 2022-11-01 14:48:40 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/templates/docs/index.html
+++ b/src/main/resources/templates/docs/index.html
@@ -1996,7 +1996,7 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: SAMEORIGIN
-Content-Length: 6084
+Content-Length: 6082
 
 {
   "success" : true,
@@ -2008,7 +2008,7 @@ Content-Length: 6084
       "amount" : "10.11",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.363622",
+      "localDateTime" : "2022-10-31T20:09:48.060687",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2018,7 +2018,7 @@ Content-Length: 6084
       "amount" : "10.12",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.367623",
+      "localDateTime" : "2022-10-31T20:09:48.064789",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2028,7 +2028,7 @@ Content-Length: 6084
       "amount" : "10.13",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.369624",
+      "localDateTime" : "2022-10-31T20:09:48.065808",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2038,7 +2038,7 @@ Content-Length: 6084
       "amount" : "10.14",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.370623",
+      "localDateTime" : "2022-10-31T20:09:48.06781",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2048,7 +2048,7 @@ Content-Length: 6084
       "amount" : "10.15",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.371477",
+      "localDateTime" : "2022-10-31T20:09:48.068809",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2058,7 +2058,7 @@ Content-Length: 6084
       "amount" : "10.16",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.373647",
+      "localDateTime" : "2022-10-31T20:09:48.069814",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2068,7 +2068,7 @@ Content-Length: 6084
       "amount" : "10.17",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.374646",
+      "localDateTime" : "2022-10-31T20:09:48.071809",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2078,7 +2078,7 @@ Content-Length: 6084
       "amount" : "10.18",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.375641",
+      "localDateTime" : "2022-10-31T20:09:48.072808",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2088,7 +2088,7 @@ Content-Length: 6084
       "amount" : "10.19",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.377924",
+      "localDateTime" : "2022-10-31T20:09:48.076146",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2098,7 +2098,7 @@ Content-Length: 6084
       "amount" : "10.110",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.378946",
+      "localDateTime" : "2022-10-31T20:09:48.07778",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2108,7 +2108,7 @@ Content-Length: 6084
       "amount" : "10.111",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.379963",
+      "localDateTime" : "2022-10-31T20:09:48.079784",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2118,7 +2118,7 @@ Content-Length: 6084
       "amount" : "10.112",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.38095",
+      "localDateTime" : "2022-10-31T20:09:48.08078",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2128,7 +2128,7 @@ Content-Length: 6084
       "amount" : "10.113",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.382947",
+      "localDateTime" : "2022-10-31T20:09:48.082779",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2138,7 +2138,7 @@ Content-Length: 6084
       "amount" : "10.114",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.383945",
+      "localDateTime" : "2022-10-31T20:09:48.083779",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2148,7 +2148,7 @@ Content-Length: 6084
       "amount" : "10.115",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.384943",
+      "localDateTime" : "2022-10-31T20:09:48.085778",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2158,7 +2158,7 @@ Content-Length: 6084
       "amount" : "10.116",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.387105",
+      "localDateTime" : "2022-10-31T20:09:48.087779",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2168,7 +2168,7 @@ Content-Length: 6084
       "amount" : "10.117",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.388104",
+      "localDateTime" : "2022-10-31T20:09:48.088776",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2178,7 +2178,7 @@ Content-Length: 6084
       "amount" : "10.118",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.389105",
+      "localDateTime" : "2022-10-31T20:09:48.090779",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2188,7 +2188,7 @@ Content-Length: 6084
       "amount" : "10.119",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.390111",
+      "localDateTime" : "2022-10-31T20:09:48.093067",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2198,19 +2198,19 @@ Content-Length: 6084
       "amount" : "10.120",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:53:18.391104",
+      "localDateTime" : "2022-10-31T20:09:48.094067",
       "total" : "202.615",
       "category" : "ETC"
     } ],
     "pageable" : {
       "sort" : {
         "empty" : true,
-        "unsorted" : true,
-        "sorted" : false
+        "sorted" : false,
+        "unsorted" : true
       },
       "offset" : 0,
-      "pageSize" : 20,
       "pageNumber" : 0,
+      "pageSize" : 20,
       "paged" : true,
       "unpaged" : false
     },
@@ -2218,12 +2218,12 @@ Content-Length: 6084
     "number" : 0,
     "sort" : {
       "empty" : true,
-      "unsorted" : true,
-      "sorted" : false
+      "sorted" : false,
+      "unsorted" : true
     },
-    "numberOfElements" : 20,
     "first" : true,
     "last" : true,
+    "numberOfElements" : 20,
     "empty" : false
   },
   "error" : null
@@ -2290,210 +2290,210 @@ Content-Length: 5448
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.717464"
+    "localDateTime" : "2022-10-31T20:09:48.427019"
   }, {
     "title" : "title",
     "amount" : "10.12",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.718466"
+    "localDateTime" : "2022-10-31T20:09:48.429019"
   }, {
     "title" : "title",
     "amount" : "10.13",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.719465"
+    "localDateTime" : "2022-10-31T20:09:48.430021"
   }, {
     "title" : "title",
     "amount" : "10.14",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.720466"
+    "localDateTime" : "2022-10-31T20:09:48.431019"
   }, {
     "title" : "title",
     "amount" : "10.15",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.721467"
+    "localDateTime" : "2022-10-31T20:09:48.433019"
   }, {
     "title" : "title",
     "amount" : "10.16",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.722465"
+    "localDateTime" : "2022-10-31T20:09:48.434019"
   }, {
     "title" : "title",
     "amount" : "10.17",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.723466"
+    "localDateTime" : "2022-10-31T20:09:48.43502"
   }, {
     "title" : "title",
     "amount" : "10.18",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.724465"
+    "localDateTime" : "2022-10-31T20:09:48.436019"
   }, {
     "title" : "title",
     "amount" : "10.19",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.726468"
+    "localDateTime" : "2022-10-31T20:09:48.438019"
   }, {
     "title" : "title",
     "amount" : "10.110",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.727464"
+    "localDateTime" : "2022-10-31T20:09:48.438893"
   }, {
     "title" : "title",
     "amount" : "10.111",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.729466"
+    "localDateTime" : "2022-10-31T20:09:48.44118"
   }, {
     "title" : "title",
     "amount" : "10.112",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.730465"
+    "localDateTime" : "2022-10-31T20:09:48.442706"
   }, {
     "title" : "title",
     "amount" : "10.113",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.732468"
+    "localDateTime" : "2022-10-31T20:09:48.444703"
   }, {
     "title" : "title",
     "amount" : "10.114",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.733464"
+    "localDateTime" : "2022-10-31T20:09:48.445704"
   }, {
     "title" : "title",
     "amount" : "10.115",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.735467"
+    "localDateTime" : "2022-10-31T20:09:48.447705"
   }, {
     "title" : "title",
     "amount" : "10.116",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.736611"
+    "localDateTime" : "2022-10-31T20:09:48.448705"
   }, {
     "title" : "title",
     "amount" : "10.117",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.737118"
+    "localDateTime" : "2022-10-31T20:09:48.449704"
   }, {
     "title" : "title",
     "amount" : "10.118",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.739125"
+    "localDateTime" : "2022-10-31T20:09:48.451703"
   }, {
     "title" : "title",
     "amount" : "10.119",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.740122"
+    "localDateTime" : "2022-10-31T20:09:48.452703"
   }, {
     "title" : "title",
     "amount" : "10.120",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.741122"
+    "localDateTime" : "2022-10-31T20:09:48.453704"
   }, {
     "title" : "title",
     "amount" : "10.121",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.743125"
+    "localDateTime" : "2022-10-31T20:09:48.454704"
   }, {
     "title" : "title",
     "amount" : "10.122",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.744123"
+    "localDateTime" : "2022-10-31T20:09:48.455789"
   }, {
     "title" : "title",
     "amount" : "10.123",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.745121"
+    "localDateTime" : "2022-10-31T20:09:48.458018"
   }, {
     "title" : "title",
     "amount" : "10.124",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.747122"
+    "localDateTime" : "2022-10-31T20:09:48.460018"
   }, {
     "title" : "title",
     "amount" : "10.125",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.74812"
+    "localDateTime" : "2022-10-31T20:09:48.461514"
   }, {
     "title" : "title",
     "amount" : "10.126",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.749121"
+    "localDateTime" : "2022-10-31T20:09:48.463033"
   }, {
     "title" : "title",
     "amount" : "10.127",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.75112"
+    "localDateTime" : "2022-10-31T20:09:48.464034"
   }, {
     "title" : "title",
     "amount" : "10.128",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.752119"
+    "localDateTime" : "2022-10-31T20:09:48.465032"
   }, {
     "title" : "title",
     "amount" : "10.129",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.753121"
+    "localDateTime" : "2022-10-31T20:09:48.466678"
   }, {
     "title" : "title",
     "amount" : "10.130",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:53:18.754119"
+    "localDateTime" : "2022-10-31T20:09:48.467974"
   } ],
   "error" : null
 }</code></pre>

--- a/src/main/resources/templates/docs/index.html
+++ b/src/main/resources/templates/docs/index.html
@@ -1996,7 +1996,7 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: SAMEORIGIN
-Content-Length: 6083
+Content-Length: 6084
 
 {
   "success" : true,
@@ -2008,7 +2008,7 @@ Content-Length: 6083
       "amount" : "10.11",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.311536",
+      "localDateTime" : "2022-10-31T14:32:43.839571",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2018,7 +2018,7 @@ Content-Length: 6083
       "amount" : "10.12",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.318535",
+      "localDateTime" : "2022-10-31T14:32:43.844572",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2028,7 +2028,7 @@ Content-Length: 6083
       "amount" : "10.13",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.319535",
+      "localDateTime" : "2022-10-31T14:32:43.845574",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2038,7 +2038,7 @@ Content-Length: 6083
       "amount" : "10.14",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.321535",
+      "localDateTime" : "2022-10-31T14:32:43.846572",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2048,7 +2048,7 @@ Content-Length: 6083
       "amount" : "10.15",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.323534",
+      "localDateTime" : "2022-10-31T14:32:43.848911",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2058,7 +2058,7 @@ Content-Length: 6083
       "amount" : "10.16",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.325536",
+      "localDateTime" : "2022-10-31T14:32:43.84969",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2068,7 +2068,7 @@ Content-Length: 6083
       "amount" : "10.17",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.326536",
+      "localDateTime" : "2022-10-31T14:32:43.851784",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2078,7 +2078,7 @@ Content-Length: 6083
       "amount" : "10.18",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.328224",
+      "localDateTime" : "2022-10-31T14:32:43.853784",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2088,7 +2088,7 @@ Content-Length: 6083
       "amount" : "10.19",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.331237",
+      "localDateTime" : "2022-10-31T14:32:43.855783",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2098,7 +2098,7 @@ Content-Length: 6083
       "amount" : "10.110",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.332765",
+      "localDateTime" : "2022-10-31T14:32:43.857785",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2108,7 +2108,7 @@ Content-Length: 6083
       "amount" : "10.111",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.33421",
+      "localDateTime" : "2022-10-31T14:32:43.859782",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2118,7 +2118,7 @@ Content-Length: 6083
       "amount" : "10.112",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.335792",
+      "localDateTime" : "2022-10-31T14:32:43.860782",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2128,7 +2128,7 @@ Content-Length: 6083
       "amount" : "10.113",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.336808",
+      "localDateTime" : "2022-10-31T14:32:43.862783",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2138,7 +2138,7 @@ Content-Length: 6083
       "amount" : "10.114",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.33781",
+      "localDateTime" : "2022-10-31T14:32:43.863787",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2148,7 +2148,7 @@ Content-Length: 6083
       "amount" : "10.115",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.338809",
+      "localDateTime" : "2022-10-31T14:32:43.865782",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2158,7 +2158,7 @@ Content-Length: 6083
       "amount" : "10.116",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.339808",
+      "localDateTime" : "2022-10-31T14:32:43.866783",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2168,7 +2168,7 @@ Content-Length: 6083
       "amount" : "10.117",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.340809",
+      "localDateTime" : "2022-10-31T14:32:43.868782",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2178,7 +2178,7 @@ Content-Length: 6083
       "amount" : "10.118",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.341809",
+      "localDateTime" : "2022-10-31T14:32:43.869782",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2188,7 +2188,7 @@ Content-Length: 6083
       "amount" : "10.119",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.342809",
+      "localDateTime" : "2022-10-31T14:32:43.871862",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2198,31 +2198,31 @@ Content-Length: 6083
       "amount" : "10.120",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-30T18:49:09.343808",
+      "localDateTime" : "2022-10-31T14:32:43.872955",
       "total" : "202.615",
       "category" : "ETC"
     } ],
     "pageable" : {
       "sort" : {
-        "unsorted" : true,
         "empty" : true,
-        "sorted" : false
+        "sorted" : false,
+        "unsorted" : true
       },
       "offset" : 0,
       "pageSize" : 20,
       "pageNumber" : 0,
-      "paged" : true,
-      "unpaged" : false
+      "unpaged" : false,
+      "paged" : true
     },
     "size" : 20,
     "number" : 0,
     "sort" : {
-      "unsorted" : true,
       "empty" : true,
-      "sorted" : false
+      "sorted" : false,
+      "unsorted" : true
     },
-    "last" : true,
     "first" : true,
+    "last" : true,
     "numberOfElements" : 20,
     "empty" : false
   },
@@ -2280,7 +2280,7 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: SAMEORIGIN
-Content-Length: 5449
+Content-Length: 5444
 
 {
   "success" : true,
@@ -2290,210 +2290,210 @@ Content-Length: 5449
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.635857"
+    "localDateTime" : "2022-10-31T14:32:44.227805"
   }, {
     "title" : "title",
     "amount" : "10.12",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.637857"
+    "localDateTime" : "2022-10-31T14:32:44.231245"
   }, {
     "title" : "title",
     "amount" : "10.13",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.638858"
+    "localDateTime" : "2022-10-31T14:32:44.233038"
   }, {
     "title" : "title",
     "amount" : "10.14",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.639857"
+    "localDateTime" : "2022-10-31T14:32:44.234355"
   }, {
     "title" : "title",
     "amount" : "10.15",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.639857"
+    "localDateTime" : "2022-10-31T14:32:44.235905"
   }, {
     "title" : "title",
     "amount" : "10.16",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.640857"
+    "localDateTime" : "2022-10-31T14:32:44.238018"
   }, {
     "title" : "title",
     "amount" : "10.17",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.641856"
+    "localDateTime" : "2022-10-31T14:32:44.239683"
   }, {
     "title" : "title",
     "amount" : "10.18",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.642859"
+    "localDateTime" : "2022-10-31T14:32:44.241384"
   }, {
     "title" : "title",
     "amount" : "10.19",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.643859"
+    "localDateTime" : "2022-10-31T14:32:44.242761"
   }, {
     "title" : "title",
     "amount" : "10.110",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.644857"
+    "localDateTime" : "2022-10-31T14:32:44.244262"
   }, {
     "title" : "title",
     "amount" : "10.111",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.646858"
+    "localDateTime" : "2022-10-31T14:32:44.246531"
   }, {
     "title" : "title",
     "amount" : "10.112",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.647859"
+    "localDateTime" : "2022-10-31T14:32:44.247549"
   }, {
     "title" : "title",
     "amount" : "10.113",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.648858"
+    "localDateTime" : "2022-10-31T14:32:44.24855"
   }, {
     "title" : "title",
     "amount" : "10.114",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.649938"
+    "localDateTime" : "2022-10-31T14:32:44.24955"
   }, {
     "title" : "title",
     "amount" : "10.115",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.650838"
+    "localDateTime" : "2022-10-31T14:32:44.25114"
   }, {
     "title" : "title",
     "amount" : "10.116",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.651968"
+    "localDateTime" : "2022-10-31T14:32:44.253353"
   }, {
     "title" : "title",
     "amount" : "10.117",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.652967"
+    "localDateTime" : "2022-10-31T14:32:44.254873"
   }, {
     "title" : "title",
     "amount" : "10.118",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.653966"
+    "localDateTime" : "2022-10-31T14:32:44.255872"
   }, {
     "title" : "title",
     "amount" : "10.119",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.654966"
+    "localDateTime" : "2022-10-31T14:32:44.257874"
   }, {
     "title" : "title",
     "amount" : "10.120",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.655968"
+    "localDateTime" : "2022-10-31T14:32:44.259066"
   }, {
     "title" : "title",
     "amount" : "10.121",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.656967"
+    "localDateTime" : "2022-10-31T14:32:44.260091"
   }, {
     "title" : "title",
     "amount" : "10.122",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.657967"
+    "localDateTime" : "2022-10-31T14:32:44.261094"
   }, {
     "title" : "title",
     "amount" : "10.123",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.658967"
+    "localDateTime" : "2022-10-31T14:32:44.26209"
   }, {
     "title" : "title",
     "amount" : "10.124",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.659967"
+    "localDateTime" : "2022-10-31T14:32:44.263093"
   }, {
     "title" : "title",
     "amount" : "10.125",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.660986"
+    "localDateTime" : "2022-10-31T14:32:44.26509"
   }, {
     "title" : "title",
     "amount" : "10.126",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.661968"
+    "localDateTime" : "2022-10-31T14:32:44.266094"
   }, {
     "title" : "title",
     "amount" : "10.127",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.662967"
+    "localDateTime" : "2022-10-31T14:32:44.268513"
   }, {
     "title" : "title",
     "amount" : "10.128",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.662967"
+    "localDateTime" : "2022-10-31T14:32:44.270239"
   }, {
     "title" : "title",
     "amount" : "10.129",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.66397"
+    "localDateTime" : "2022-10-31T14:32:44.27225"
   }, {
     "title" : "title",
     "amount" : "10.130",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-30T18:49:09.665967"
+    "localDateTime" : "2022-10-31T14:32:44.274251"
   } ],
   "error" : null
 }</code></pre>
@@ -3045,7 +3045,7 @@ Content-Length: 2260
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-10-30 18:48:49 +0900
+Last updated 2022-10-30 18:51:14 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/resources/templates/docs/index.html
+++ b/src/main/resources/templates/docs/index.html
@@ -2008,7 +2008,7 @@ Content-Length: 6084
       "amount" : "10.11",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.067361",
+      "localDateTime" : "2022-10-31T19:53:18.363622",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2018,7 +2018,7 @@ Content-Length: 6084
       "amount" : "10.12",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.073361",
+      "localDateTime" : "2022-10-31T19:53:18.367623",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2028,7 +2028,7 @@ Content-Length: 6084
       "amount" : "10.13",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.075363",
+      "localDateTime" : "2022-10-31T19:53:18.369624",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2038,7 +2038,7 @@ Content-Length: 6084
       "amount" : "10.14",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.076363",
+      "localDateTime" : "2022-10-31T19:53:18.370623",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2048,7 +2048,7 @@ Content-Length: 6084
       "amount" : "10.15",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.079062",
+      "localDateTime" : "2022-10-31T19:53:18.371477",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2058,7 +2058,7 @@ Content-Length: 6084
       "amount" : "10.16",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.080146",
+      "localDateTime" : "2022-10-31T19:53:18.373647",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2068,7 +2068,7 @@ Content-Length: 6084
       "amount" : "10.17",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.082167",
+      "localDateTime" : "2022-10-31T19:53:18.374646",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2078,7 +2078,7 @@ Content-Length: 6084
       "amount" : "10.18",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.084182",
+      "localDateTime" : "2022-10-31T19:53:18.375641",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2088,7 +2088,7 @@ Content-Length: 6084
       "amount" : "10.19",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.086428",
+      "localDateTime" : "2022-10-31T19:53:18.377924",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2098,7 +2098,7 @@ Content-Length: 6084
       "amount" : "10.110",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.088646",
+      "localDateTime" : "2022-10-31T19:53:18.378946",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2108,7 +2108,7 @@ Content-Length: 6084
       "amount" : "10.111",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.089979",
+      "localDateTime" : "2022-10-31T19:53:18.379963",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2118,7 +2118,7 @@ Content-Length: 6084
       "amount" : "10.112",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.091978",
+      "localDateTime" : "2022-10-31T19:53:18.38095",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2128,7 +2128,7 @@ Content-Length: 6084
       "amount" : "10.113",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.094455",
+      "localDateTime" : "2022-10-31T19:53:18.382947",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2138,7 +2138,7 @@ Content-Length: 6084
       "amount" : "10.114",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.096508",
+      "localDateTime" : "2022-10-31T19:53:18.383945",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2148,7 +2148,7 @@ Content-Length: 6084
       "amount" : "10.115",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.098506",
+      "localDateTime" : "2022-10-31T19:53:18.384943",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2158,7 +2158,7 @@ Content-Length: 6084
       "amount" : "10.116",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.099506",
+      "localDateTime" : "2022-10-31T19:53:18.387105",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2168,7 +2168,7 @@ Content-Length: 6084
       "amount" : "10.117",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.101505",
+      "localDateTime" : "2022-10-31T19:53:18.388104",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2178,7 +2178,7 @@ Content-Length: 6084
       "amount" : "10.118",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.10251",
+      "localDateTime" : "2022-10-31T19:53:18.389105",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2188,7 +2188,7 @@ Content-Length: 6084
       "amount" : "10.119",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.105375",
+      "localDateTime" : "2022-10-31T19:53:18.390111",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2198,28 +2198,28 @@ Content-Length: 6084
       "amount" : "10.120",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T19:23:37.106372",
+      "localDateTime" : "2022-10-31T19:53:18.391104",
       "total" : "202.615",
       "category" : "ETC"
     } ],
     "pageable" : {
       "sort" : {
         "empty" : true,
-        "sorted" : false,
-        "unsorted" : true
+        "unsorted" : true,
+        "sorted" : false
       },
       "offset" : 0,
-      "pageNumber" : 0,
       "pageSize" : 20,
-      "unpaged" : false,
-      "paged" : true
+      "pageNumber" : 0,
+      "paged" : true,
+      "unpaged" : false
     },
     "size" : 20,
     "number" : 0,
     "sort" : {
       "empty" : true,
-      "sorted" : false,
-      "unsorted" : true
+      "unsorted" : true,
+      "sorted" : false
     },
     "numberOfElements" : 20,
     "first" : true,
@@ -2280,7 +2280,7 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: SAMEORIGIN
-Content-Length: 5447
+Content-Length: 5448
 
 {
   "success" : true,
@@ -2290,210 +2290,210 @@ Content-Length: 5447
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.500785"
+    "localDateTime" : "2022-10-31T19:53:18.717464"
   }, {
     "title" : "title",
     "amount" : "10.12",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.501803"
+    "localDateTime" : "2022-10-31T19:53:18.718466"
   }, {
     "title" : "title",
     "amount" : "10.13",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.503807"
+    "localDateTime" : "2022-10-31T19:53:18.719465"
   }, {
     "title" : "title",
     "amount" : "10.14",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.504804"
+    "localDateTime" : "2022-10-31T19:53:18.720466"
   }, {
     "title" : "title",
     "amount" : "10.15",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.506805"
+    "localDateTime" : "2022-10-31T19:53:18.721467"
   }, {
     "title" : "title",
     "amount" : "10.16",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.507804"
+    "localDateTime" : "2022-10-31T19:53:18.722465"
   }, {
     "title" : "title",
     "amount" : "10.17",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.508677"
+    "localDateTime" : "2022-10-31T19:53:18.723466"
   }, {
     "title" : "title",
     "amount" : "10.18",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.509954"
+    "localDateTime" : "2022-10-31T19:53:18.724465"
   }, {
     "title" : "title",
     "amount" : "10.19",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.510954"
+    "localDateTime" : "2022-10-31T19:53:18.726468"
   }, {
     "title" : "title",
     "amount" : "10.110",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.511952"
+    "localDateTime" : "2022-10-31T19:53:18.727464"
   }, {
     "title" : "title",
     "amount" : "10.111",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.512952"
+    "localDateTime" : "2022-10-31T19:53:18.729466"
   }, {
     "title" : "title",
     "amount" : "10.112",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.514843"
+    "localDateTime" : "2022-10-31T19:53:18.730465"
   }, {
     "title" : "title",
     "amount" : "10.113",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.515863"
+    "localDateTime" : "2022-10-31T19:53:18.732468"
   }, {
     "title" : "title",
     "amount" : "10.114",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.517868"
+    "localDateTime" : "2022-10-31T19:53:18.733464"
   }, {
     "title" : "title",
     "amount" : "10.115",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.518867"
+    "localDateTime" : "2022-10-31T19:53:18.735467"
   }, {
     "title" : "title",
     "amount" : "10.116",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.519868"
+    "localDateTime" : "2022-10-31T19:53:18.736611"
   }, {
     "title" : "title",
     "amount" : "10.117",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.52093"
+    "localDateTime" : "2022-10-31T19:53:18.737118"
   }, {
     "title" : "title",
     "amount" : "10.118",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.522073"
+    "localDateTime" : "2022-10-31T19:53:18.739125"
   }, {
     "title" : "title",
     "amount" : "10.119",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.523144"
+    "localDateTime" : "2022-10-31T19:53:18.740122"
   }, {
     "title" : "title",
     "amount" : "10.120",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.524108"
+    "localDateTime" : "2022-10-31T19:53:18.741122"
   }, {
     "title" : "title",
     "amount" : "10.121",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.525088"
+    "localDateTime" : "2022-10-31T19:53:18.743125"
   }, {
     "title" : "title",
     "amount" : "10.122",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.52607"
+    "localDateTime" : "2022-10-31T19:53:18.744123"
   }, {
     "title" : "title",
     "amount" : "10.123",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.52707"
+    "localDateTime" : "2022-10-31T19:53:18.745121"
   }, {
     "title" : "title",
     "amount" : "10.124",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.528069"
+    "localDateTime" : "2022-10-31T19:53:18.747122"
   }, {
     "title" : "title",
     "amount" : "10.125",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.529088"
+    "localDateTime" : "2022-10-31T19:53:18.74812"
   }, {
     "title" : "title",
     "amount" : "10.126",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.530069"
+    "localDateTime" : "2022-10-31T19:53:18.749121"
   }, {
     "title" : "title",
     "amount" : "10.127",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.530069"
+    "localDateTime" : "2022-10-31T19:53:18.75112"
   }, {
     "title" : "title",
     "amount" : "10.128",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.531069"
+    "localDateTime" : "2022-10-31T19:53:18.752119"
   }, {
     "title" : "title",
     "amount" : "10.129",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.533069"
+    "localDateTime" : "2022-10-31T19:53:18.753121"
   }, {
     "title" : "title",
     "amount" : "10.130",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T19:23:37.534073"
+    "localDateTime" : "2022-10-31T19:53:18.754119"
   } ],
   "error" : null
 }</code></pre>

--- a/src/main/resources/templates/docs/index.html
+++ b/src/main/resources/templates/docs/index.html
@@ -1996,7 +1996,7 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: SAMEORIGIN
-Content-Length: 6085
+Content-Length: 6084
 
 {
   "success" : true,
@@ -2008,7 +2008,7 @@ Content-Length: 6085
       "amount" : "10.11",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:04.985895",
+      "localDateTime" : "2022-10-31T19:23:37.067361",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2018,7 +2018,7 @@ Content-Length: 6085
       "amount" : "10.12",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:04.991035",
+      "localDateTime" : "2022-10-31T19:23:37.073361",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2028,7 +2028,7 @@ Content-Length: 6085
       "amount" : "10.13",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:04.992034",
+      "localDateTime" : "2022-10-31T19:23:37.075363",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2038,7 +2038,7 @@ Content-Length: 6085
       "amount" : "10.14",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:04.993037",
+      "localDateTime" : "2022-10-31T19:23:37.076363",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2048,7 +2048,7 @@ Content-Length: 6085
       "amount" : "10.15",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:04.995038",
+      "localDateTime" : "2022-10-31T19:23:37.079062",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2058,7 +2058,7 @@ Content-Length: 6085
       "amount" : "10.16",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:04.996035",
+      "localDateTime" : "2022-10-31T19:23:37.080146",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2068,7 +2068,7 @@ Content-Length: 6085
       "amount" : "10.17",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:04.998036",
+      "localDateTime" : "2022-10-31T19:23:37.082167",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2078,7 +2078,7 @@ Content-Length: 6085
       "amount" : "10.18",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:04.999036",
+      "localDateTime" : "2022-10-31T19:23:37.084182",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2088,7 +2088,7 @@ Content-Length: 6085
       "amount" : "10.19",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:05.001035",
+      "localDateTime" : "2022-10-31T19:23:37.086428",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2098,7 +2098,7 @@ Content-Length: 6085
       "amount" : "10.110",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:05.002036",
+      "localDateTime" : "2022-10-31T19:23:37.088646",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2108,7 +2108,7 @@ Content-Length: 6085
       "amount" : "10.111",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:05.004121",
+      "localDateTime" : "2022-10-31T19:23:37.089979",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2118,7 +2118,7 @@ Content-Length: 6085
       "amount" : "10.112",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:05.005316",
+      "localDateTime" : "2022-10-31T19:23:37.091978",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2128,7 +2128,7 @@ Content-Length: 6085
       "amount" : "10.113",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:05.006314",
+      "localDateTime" : "2022-10-31T19:23:37.094455",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2138,7 +2138,7 @@ Content-Length: 6085
       "amount" : "10.114",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:05.007315",
+      "localDateTime" : "2022-10-31T19:23:37.096508",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2148,7 +2148,7 @@ Content-Length: 6085
       "amount" : "10.115",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:05.008314",
+      "localDateTime" : "2022-10-31T19:23:37.098506",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2158,7 +2158,7 @@ Content-Length: 6085
       "amount" : "10.116",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:05.010319",
+      "localDateTime" : "2022-10-31T19:23:37.099506",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2168,7 +2168,7 @@ Content-Length: 6085
       "amount" : "10.117",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:05.011316",
+      "localDateTime" : "2022-10-31T19:23:37.101505",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2178,7 +2178,7 @@ Content-Length: 6085
       "amount" : "10.118",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:05.013314",
+      "localDateTime" : "2022-10-31T19:23:37.10251",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2188,7 +2188,7 @@ Content-Length: 6085
       "amount" : "10.119",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:05.015318",
+      "localDateTime" : "2022-10-31T19:23:37.105375",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2198,32 +2198,32 @@ Content-Length: 6085
       "amount" : "10.120",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T15:56:05.016315",
+      "localDateTime" : "2022-10-31T19:23:37.106372",
       "total" : "202.615",
       "category" : "ETC"
     } ],
     "pageable" : {
       "sort" : {
+        "empty" : true,
         "sorted" : false,
-        "unsorted" : true,
-        "empty" : true
+        "unsorted" : true
       },
-      "pageSize" : 20,
-      "pageNumber" : 0,
       "offset" : 0,
+      "pageNumber" : 0,
+      "pageSize" : 20,
       "unpaged" : false,
       "paged" : true
     },
+    "size" : 20,
     "number" : 0,
     "sort" : {
+      "empty" : true,
       "sorted" : false,
-      "unsorted" : true,
-      "empty" : true
+      "unsorted" : true
     },
     "numberOfElements" : 20,
     "first" : true,
     "last" : true,
-    "size" : 20,
     "empty" : false
   },
   "error" : null
@@ -2280,7 +2280,7 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: SAMEORIGIN
-Content-Length: 5444
+Content-Length: 5447
 
 {
   "success" : true,
@@ -2290,210 +2290,210 @@ Content-Length: 5444
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.268513"
+    "localDateTime" : "2022-10-31T19:23:37.500785"
   }, {
     "title" : "title",
     "amount" : "10.12",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.26951"
+    "localDateTime" : "2022-10-31T19:23:37.501803"
   }, {
     "title" : "title",
     "amount" : "10.13",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.270508"
+    "localDateTime" : "2022-10-31T19:23:37.503807"
   }, {
     "title" : "title",
     "amount" : "10.14",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.271511"
+    "localDateTime" : "2022-10-31T19:23:37.504804"
   }, {
     "title" : "title",
     "amount" : "10.15",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.27251"
+    "localDateTime" : "2022-10-31T19:23:37.506805"
   }, {
     "title" : "title",
     "amount" : "10.16",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.27251"
+    "localDateTime" : "2022-10-31T19:23:37.507804"
   }, {
     "title" : "title",
     "amount" : "10.17",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.273509"
+    "localDateTime" : "2022-10-31T19:23:37.508677"
   }, {
     "title" : "title",
     "amount" : "10.18",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.274509"
+    "localDateTime" : "2022-10-31T19:23:37.509954"
   }, {
     "title" : "title",
     "amount" : "10.19",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.274509"
+    "localDateTime" : "2022-10-31T19:23:37.510954"
   }, {
     "title" : "title",
     "amount" : "10.110",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.275511"
+    "localDateTime" : "2022-10-31T19:23:37.511952"
   }, {
     "title" : "title",
     "amount" : "10.111",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.276509"
+    "localDateTime" : "2022-10-31T19:23:37.512952"
   }, {
     "title" : "title",
     "amount" : "10.112",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.276509"
+    "localDateTime" : "2022-10-31T19:23:37.514843"
   }, {
     "title" : "title",
     "amount" : "10.113",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.277512"
+    "localDateTime" : "2022-10-31T19:23:37.515863"
   }, {
     "title" : "title",
     "amount" : "10.114",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.278511"
+    "localDateTime" : "2022-10-31T19:23:37.517868"
   }, {
     "title" : "title",
     "amount" : "10.115",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.279509"
+    "localDateTime" : "2022-10-31T19:23:37.518867"
   }, {
     "title" : "title",
     "amount" : "10.116",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.279509"
+    "localDateTime" : "2022-10-31T19:23:37.519868"
   }, {
     "title" : "title",
     "amount" : "10.117",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.280511"
+    "localDateTime" : "2022-10-31T19:23:37.52093"
   }, {
     "title" : "title",
     "amount" : "10.118",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.28151"
+    "localDateTime" : "2022-10-31T19:23:37.522073"
   }, {
     "title" : "title",
     "amount" : "10.119",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.28251"
+    "localDateTime" : "2022-10-31T19:23:37.523144"
   }, {
     "title" : "title",
     "amount" : "10.120",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.28351"
+    "localDateTime" : "2022-10-31T19:23:37.524108"
   }, {
     "title" : "title",
     "amount" : "10.121",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.284509"
+    "localDateTime" : "2022-10-31T19:23:37.525088"
   }, {
     "title" : "title",
     "amount" : "10.122",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.285512"
+    "localDateTime" : "2022-10-31T19:23:37.52607"
   }, {
     "title" : "title",
     "amount" : "10.123",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.286511"
+    "localDateTime" : "2022-10-31T19:23:37.52707"
   }, {
     "title" : "title",
     "amount" : "10.124",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.287511"
+    "localDateTime" : "2022-10-31T19:23:37.528069"
   }, {
     "title" : "title",
     "amount" : "10.125",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.288511"
+    "localDateTime" : "2022-10-31T19:23:37.529088"
   }, {
     "title" : "title",
     "amount" : "10.126",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.289604"
+    "localDateTime" : "2022-10-31T19:23:37.530069"
   }, {
     "title" : "title",
     "amount" : "10.127",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.290613"
+    "localDateTime" : "2022-10-31T19:23:37.530069"
   }, {
     "title" : "title",
     "amount" : "10.128",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.291612"
+    "localDateTime" : "2022-10-31T19:23:37.531069"
   }, {
     "title" : "title",
     "amount" : "10.129",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.291612"
+    "localDateTime" : "2022-10-31T19:23:37.533069"
   }, {
     "title" : "title",
     "amount" : "10.130",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T15:56:05.292614"
+    "localDateTime" : "2022-10-31T19:23:37.534073"
   } ],
   "error" : null
 }</code></pre>

--- a/src/main/resources/templates/docs/index.html
+++ b/src/main/resources/templates/docs/index.html
@@ -1996,7 +1996,7 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: SAMEORIGIN
-Content-Length: 6084
+Content-Length: 6081
 
 {
   "success" : true,
@@ -2008,7 +2008,7 @@ Content-Length: 6084
       "amount" : "10.11",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.839571",
+      "localDateTime" : "2022-10-31T15:41:40.779861",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2018,7 +2018,7 @@ Content-Length: 6084
       "amount" : "10.12",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.844572",
+      "localDateTime" : "2022-10-31T15:41:40.785879",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2028,7 +2028,7 @@ Content-Length: 6084
       "amount" : "10.13",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.845574",
+      "localDateTime" : "2022-10-31T15:41:40.787862",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2038,7 +2038,7 @@ Content-Length: 6084
       "amount" : "10.14",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.846572",
+      "localDateTime" : "2022-10-31T15:41:40.788864",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2048,7 +2048,7 @@ Content-Length: 6084
       "amount" : "10.15",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.848911",
+      "localDateTime" : "2022-10-31T15:41:40.790864",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2058,7 +2058,7 @@ Content-Length: 6084
       "amount" : "10.16",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.84969",
+      "localDateTime" : "2022-10-31T15:41:40.791864",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2068,7 +2068,7 @@ Content-Length: 6084
       "amount" : "10.17",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.851784",
+      "localDateTime" : "2022-10-31T15:41:40.793862",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2078,7 +2078,7 @@ Content-Length: 6084
       "amount" : "10.18",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.853784",
+      "localDateTime" : "2022-10-31T15:41:40.794863",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2088,7 +2088,7 @@ Content-Length: 6084
       "amount" : "10.19",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.855783",
+      "localDateTime" : "2022-10-31T15:41:40.79655",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2098,7 +2098,7 @@ Content-Length: 6084
       "amount" : "10.110",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.857785",
+      "localDateTime" : "2022-10-31T15:41:40.798569",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2108,7 +2108,7 @@ Content-Length: 6084
       "amount" : "10.111",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.859782",
+      "localDateTime" : "2022-10-31T15:41:40.799573",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2118,7 +2118,7 @@ Content-Length: 6084
       "amount" : "10.112",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.860782",
+      "localDateTime" : "2022-10-31T15:41:40.800572",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2128,7 +2128,7 @@ Content-Length: 6084
       "amount" : "10.113",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.862783",
+      "localDateTime" : "2022-10-31T15:41:40.802571",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2138,7 +2138,7 @@ Content-Length: 6084
       "amount" : "10.114",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.863787",
+      "localDateTime" : "2022-10-31T15:41:40.80357",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2148,7 +2148,7 @@ Content-Length: 6084
       "amount" : "10.115",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.865782",
+      "localDateTime" : "2022-10-31T15:41:40.80457",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2158,7 +2158,7 @@ Content-Length: 6084
       "amount" : "10.116",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.866783",
+      "localDateTime" : "2022-10-31T15:41:40.80657",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2168,7 +2168,7 @@ Content-Length: 6084
       "amount" : "10.117",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.868782",
+      "localDateTime" : "2022-10-31T15:41:40.808568",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2178,7 +2178,7 @@ Content-Length: 6084
       "amount" : "10.118",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.869782",
+      "localDateTime" : "2022-10-31T15:41:40.809569",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2188,7 +2188,7 @@ Content-Length: 6084
       "amount" : "10.119",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.871862",
+      "localDateTime" : "2022-10-31T15:41:40.811569",
       "total" : "202.615",
       "category" : "ETC"
     }, {
@@ -2198,7 +2198,7 @@ Content-Length: 6084
       "amount" : "10.120",
       "sponsor" : "name",
       "beneficiary" : "name",
-      "localDateTime" : "2022-10-31T14:32:43.872955",
+      "localDateTime" : "2022-10-31T15:41:40.813575",
       "total" : "202.615",
       "category" : "ETC"
     } ],
@@ -2221,9 +2221,9 @@ Content-Length: 6084
       "sorted" : false,
       "unsorted" : true
     },
+    "numberOfElements" : 20,
     "first" : true,
     "last" : true,
-    "numberOfElements" : 20,
     "empty" : false
   },
   "error" : null
@@ -2280,7 +2280,7 @@ Pragma: no-cache
 Expires: 0
 Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: SAMEORIGIN
-Content-Length: 5444
+Content-Length: 5448
 
 {
   "success" : true,
@@ -2290,210 +2290,210 @@ Content-Length: 5444
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.227805"
+    "localDateTime" : "2022-10-31T15:41:41.104651"
   }, {
     "title" : "title",
     "amount" : "10.12",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.231245"
+    "localDateTime" : "2022-10-31T15:41:41.10565"
   }, {
     "title" : "title",
     "amount" : "10.13",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.233038"
+    "localDateTime" : "2022-10-31T15:41:41.10665"
   }, {
     "title" : "title",
     "amount" : "10.14",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.234355"
+    "localDateTime" : "2022-10-31T15:41:41.107652"
   }, {
     "title" : "title",
     "amount" : "10.15",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.235905"
+    "localDateTime" : "2022-10-31T15:41:41.107652"
   }, {
     "title" : "title",
     "amount" : "10.16",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.238018"
+    "localDateTime" : "2022-10-31T15:41:41.108658"
   }, {
     "title" : "title",
     "amount" : "10.17",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.239683"
+    "localDateTime" : "2022-10-31T15:41:41.109652"
   }, {
     "title" : "title",
     "amount" : "10.18",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.241384"
+    "localDateTime" : "2022-10-31T15:41:41.109652"
   }, {
     "title" : "title",
     "amount" : "10.19",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.242761"
+    "localDateTime" : "2022-10-31T15:41:41.110651"
   }, {
     "title" : "title",
     "amount" : "10.110",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.244262"
+    "localDateTime" : "2022-10-31T15:41:41.110651"
   }, {
     "title" : "title",
     "amount" : "10.111",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.246531"
+    "localDateTime" : "2022-10-31T15:41:41.111651"
   }, {
     "title" : "title",
     "amount" : "10.112",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.247549"
+    "localDateTime" : "2022-10-31T15:41:41.111651"
   }, {
     "title" : "title",
     "amount" : "10.113",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.24855"
+    "localDateTime" : "2022-10-31T15:41:41.112652"
   }, {
     "title" : "title",
     "amount" : "10.114",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.24955"
+    "localDateTime" : "2022-10-31T15:41:41.113755"
   }, {
     "title" : "title",
     "amount" : "10.115",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.25114"
+    "localDateTime" : "2022-10-31T15:41:41.114796"
   }, {
     "title" : "title",
     "amount" : "10.116",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.253353"
+    "localDateTime" : "2022-10-31T15:41:41.114796"
   }, {
     "title" : "title",
     "amount" : "10.117",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.254873"
+    "localDateTime" : "2022-10-31T15:41:41.115793"
   }, {
     "title" : "title",
     "amount" : "10.118",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.255872"
+    "localDateTime" : "2022-10-31T15:41:41.115793"
   }, {
     "title" : "title",
     "amount" : "10.119",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.257874"
+    "localDateTime" : "2022-10-31T15:41:41.116794"
   }, {
     "title" : "title",
     "amount" : "10.120",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.259066"
+    "localDateTime" : "2022-10-31T15:41:41.117792"
   }, {
     "title" : "title",
     "amount" : "10.121",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.260091"
+    "localDateTime" : "2022-10-31T15:41:41.118792"
   }, {
     "title" : "title",
     "amount" : "10.122",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.261094"
+    "localDateTime" : "2022-10-31T15:41:41.119794"
   }, {
     "title" : "title",
     "amount" : "10.123",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.26209"
+    "localDateTime" : "2022-10-31T15:41:41.120796"
   }, {
     "title" : "title",
     "amount" : "10.124",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.263093"
+    "localDateTime" : "2022-10-31T15:41:41.121793"
   }, {
     "title" : "title",
     "amount" : "10.125",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.26509"
+    "localDateTime" : "2022-10-31T15:41:41.121793"
   }, {
     "title" : "title",
     "amount" : "10.126",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.266094"
+    "localDateTime" : "2022-10-31T15:41:41.122793"
   }, {
     "title" : "title",
     "amount" : "10.127",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.268513"
+    "localDateTime" : "2022-10-31T15:41:41.123793"
   }, {
     "title" : "title",
     "amount" : "10.128",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.270239"
+    "localDateTime" : "2022-10-31T15:41:41.124793"
   }, {
     "title" : "title",
     "amount" : "10.129",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.27225"
+    "localDateTime" : "2022-10-31T15:41:41.124793"
   }, {
     "title" : "title",
     "amount" : "10.130",
     "total" : "303.87",
     "postId" : 34,
     "category" : "ETC",
-    "localDateTime" : "2022-10-31T14:32:44.274251"
+    "localDateTime" : "2022-10-31T15:41:41.125793"
   } ],
   "error" : null
 }</code></pre>

--- a/src/test/java/com/donation/common/CommentFixtures.java
+++ b/src/test/java/com/donation/common/CommentFixtures.java
@@ -1,5 +1,6 @@
 package com.donation.common;
 
+import com.donation.common.request.comment.CommentSaveReqDto;
 import com.donation.domain.entites.Comment;
 import com.donation.domain.entites.Post;
 import com.donation.domain.entites.User;
@@ -14,6 +15,13 @@ import static com.donation.common.UserFixtures.createUser;
 public class CommentFixtures {
     public static String 일반_댓글 = "일반 댓글 입니다.";
     public static String 일반_대댓글 = "일반 대댓글 입니다.";
+
+    /* 댓글 생성 */
+    public static CommentSaveReqDto 댓글_생성_DTO(){
+        return CommentSaveReqDto.builder()
+                .message(일반_댓글)
+                .build();
+    }
 
     public static Comment createParentComment() {
         return Comment.parent(createUser(1L), createPost(1L), 일반_댓글);

--- a/src/test/java/com/donation/common/CommentFixtures.java
+++ b/src/test/java/com/donation/common/CommentFixtures.java
@@ -1,19 +1,45 @@
 package com.donation.common;
 
 import com.donation.domain.entites.Comment;
+import com.donation.domain.entites.Post;
+import com.donation.domain.entites.User;
 
-import static com.donation.common.PostFixtures.*;
-import static com.donation.common.UserFixtures.*;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.donation.common.PostFixtures.createPost;
+import static com.donation.common.UserFixtures.createUser;
 
 public class CommentFixtures {
     public static String 일반_댓글 = "일반 댓글 입니다.";
     public static String 일반_대댓글 = "일반 대댓글 입니다.";
 
-    public static Comment createParentComment(){
-        return Comment.parent(createUser(1L), createPost(), 일반_댓글);
+    public static Comment createParentComment() {
+        return Comment.parent(createUser(1L), createPost(1L), 일반_댓글);
     }
 
-    public static Comment createChildComment(Comment parent){
-        return Comment.child(createUser(2L), createPost(),일반_대댓글, parent);
+    public static Comment createParentComment(User user, Post post) {
+        return Comment.parent(user, post, 일반_댓글);
+    }
+
+    public static Comment createChildComment(Comment parent) {
+        return Comment.child(createUser(2L), createPost(1L), 일반_대댓글, parent);
+    }
+
+    public static Comment createChildComment(User user, Post post, Comment parent) {
+        return Comment.child(user, post, 일반_대댓글, parent);
+    }
+
+    public static List<Comment> createParentCommentList(int startNum, int lastNum, User user, Post post) {
+        return IntStream.range(startNum, lastNum)
+                .mapToObj(i -> createParentComment(user, post))
+                .collect(Collectors.toList());
+    }
+
+    public static List<Comment> createChildCommentList(int startNum, int lastNum, User user, Post post, Comment parent) {
+        return IntStream.range(startNum, lastNum)
+                .mapToObj(i -> createChildComment(user, post, parent))
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/donation/common/CommentFixtures.java
+++ b/src/test/java/com/donation/common/CommentFixtures.java
@@ -50,4 +50,5 @@ public class CommentFixtures {
                 .mapToObj(i -> createChildComment(user, post, parent))
                 .collect(Collectors.toList());
     }
+
 }

--- a/src/test/java/com/donation/common/CommentFixtures.java
+++ b/src/test/java/com/donation/common/CommentFixtures.java
@@ -17,9 +17,9 @@ public class CommentFixtures {
     public static String 일반_대댓글 = "일반 대댓글 입니다.";
 
     /* 댓글 생성 */
-    public static CommentSaveReqDto 댓글_생성_DTO(){
+    public static CommentSaveReqDto 댓글_생성_DTO(String message){
         return CommentSaveReqDto.builder()
-                .message(일반_댓글)
+                .message(message)
                 .build();
     }
 

--- a/src/test/java/com/donation/common/CommentFixtures.java
+++ b/src/test/java/com/donation/common/CommentFixtures.java
@@ -1,0 +1,19 @@
+package com.donation.common;
+
+import com.donation.domain.entites.Comment;
+
+import static com.donation.common.PostFixtures.*;
+import static com.donation.common.UserFixtures.*;
+
+public class CommentFixtures {
+    public static String 일반_댓글 = "일반 댓글 입니다.";
+    public static String 일반_대댓글 = "일반 대댓글 입니다.";
+
+    public static Comment createParentComment(){
+        return Comment.parent(createUser(1L), createPost(), 일반_댓글);
+    }
+
+    public static Comment createChildComment(Comment parent){
+        return Comment.child(createUser(2L), createPost(),일반_대댓글, parent);
+    }
+}

--- a/src/test/java/com/donation/common/PostFixtures.java
+++ b/src/test/java/com/donation/common/PostFixtures.java
@@ -104,6 +104,16 @@ public class PostFixtures {
                 .build();
     }
 
+    public static Post createPost(Long id){
+        return Post.builder()
+                .id(id)
+                .write(일반_게시물_게시글)
+                .amount(일반_게시물_기부금)
+                .state(일반_게시물_상태)
+                .category(일반_게시물_카테고리)
+                .build();
+    }
+
     public static Post createPost(User user){
         return Post.builder()
                 .user(user)

--- a/src/test/java/com/donation/controller/comment/CommentControllerTest.java
+++ b/src/test/java/com/donation/controller/comment/CommentControllerTest.java
@@ -1,0 +1,161 @@
+package com.donation.controller.comment;
+
+import com.donation.common.PostFixtures;
+import com.donation.common.UserFixtures;
+import com.donation.common.response.comment.CommentResponse;
+import com.donation.common.response.comment.ReplyResponse;
+import com.donation.common.utils.ControllerTest;
+import com.donation.domain.entites.Comment;
+import com.donation.domain.entites.Post;
+import com.donation.domain.entites.User;
+import com.donation.service.comment.CommentService;
+import com.donation.web.controller.comment.CommentController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.donation.common.CommentFixtures.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CommentController.class)
+public class CommentControllerTest extends ControllerTest {
+
+    @MockBean
+    private CommentService commentService;
+
+
+    @Test
+    @DisplayName("댓글요청이 정상적으로 등록된다.")
+    void 댓글요청이_정상적으로_등록된다() throws Exception {
+        //given
+        Long userId = 1L;
+        Long postId = 1L;
+
+        given(commentService.saveComment(postId, userId, 댓글_생성_DTO(일반_댓글))).willReturn(1L);
+
+        //expect
+        mockMvc.perform(post("/api/post/{id}/comment/{userId}", postId, userId)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(댓글_생성_DTO(일반_댓글)))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value("true"))
+                .andExpect(jsonPath("$.data").isEmpty())
+                .andExpect(jsonPath("$.error").isEmpty())
+                .andDo(document("comment-save",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("id").description("포스트 ID"),
+                                parameterWithName("userId").description("유저 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("대댓글요청이 정상적으로 등록된다.")
+    void 댓글_작성시_댓글_내용이_100자를_경우_예외를_던진다() throws Exception {
+        //given
+        Long userId = 1L;
+        Long commentId = 1L;
+
+        given(commentService.saveReply(commentId, userId, 댓글_생성_DTO(일반_댓글))).willReturn(1L);
+
+        //expect
+        mockMvc.perform(post("/api/comment/{id}/reply/{userId}", commentId, userId)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(댓글_생성_DTO(일반_대댓글)))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value("true"))
+                .andExpect(jsonPath("$.data").isEmpty())
+                .andExpect(jsonPath("$.error").isEmpty())
+                .andDo(document("reply-save",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("id").description("댓글 ID"),
+                                parameterWithName("userId").description("유저 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 요청이 정상적으로 동작한다.")
+    void 댓글_삭제_요청이_정상적으로_동작한다() throws Exception{
+        //given
+        Long userId = 1L;
+        Long commentId = 1L;
+
+        willDoNothing().given(commentService).delete(commentId,userId);
+
+        //expect
+        mockMvc.perform(delete("/api/comment/{id}/{userId}", commentId, userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value("true"))
+                .andExpect(jsonPath("$.data").isEmpty())
+                .andExpect(jsonPath("$.error").isEmpty())
+                .andDo(document("comment-delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("id").description("댓글 ID"),
+                                parameterWithName("userId").description("유저 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("게시물ID를 통한 댓글 조회 요청이 정상적으로 동작한다")
+    void 게시물ID를_통한_댓글_조회_요청이_정상적으로_동작한다() throws Exception{
+        //given
+        User user = UserFixtures.createUser(1L);
+        Post post = PostFixtures.createPost(UserFixtures.createUser(1L));
+        Comment parent = createParentComment(user, post);
+        List<ReplyResponse> replies = createChildCommentList(0, 2, UserFixtures.createUser(2L), post, parent).stream()
+                .map(Reply -> ReplyResponse.of(Reply, Reply.getUser()))
+                .collect(Collectors.toList());
+        given(commentService.findComment(1L)).willReturn(List.of(CommentResponse.of(parent, user, replies)));
+
+        //expect
+        mockMvc.perform(get("/api/post/{id}/comment", 1L))
+                .andExpect(status().isOk())
+                .andDo(document("comment-getList",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("id").description("포스트 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data[0].id").description("댓글 ID"),
+                                fieldWithPath("data[0].name").description("회원 이름"),
+                                fieldWithPath("data[0].profileImage").description("회원 프로필 이미지"),
+                                fieldWithPath("data[0].content").description("댓글 내용"),
+                                fieldWithPath("data[0].createdAt").description("댓글 생성일"),
+                                fieldWithPath("data[0].doesExist").description("댓글 삭제 여부"),
+                                fieldWithPath("data[0].replies[0].id").description("댓글 ID"),
+                                fieldWithPath("data[0].replies[0].name").description("회원 이름"),
+                                fieldWithPath("data[0].replies[0].profileImage").description("회원 프로필 이미지"),
+                                fieldWithPath("data[0].replies[0].content").description("대댓글 내용"),
+                                fieldWithPath("data[0].replies[0].createdAt").description("대댓글 생성일"),
+                                fieldWithPath("error").description("에러 발생시 오류 반환")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/donation/domain/CommentTest.java
+++ b/src/test/java/com/donation/domain/CommentTest.java
@@ -1,0 +1,54 @@
+package com.donation.domain;
+
+import com.donation.domain.entites.Comment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.donation.common.CommentFixtures.createChildComment;
+import static com.donation.common.CommentFixtures.createParentComment;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class CommentTest {
+
+    @Test
+    @DisplayName("댓글이 정상적으로 작성된다.")
+    void 댓글이_정상적으로_생성된다(){
+        //given & when & then
+        assertDoesNotThrow(() -> createParentComment());
+    }
+
+    @Test
+    @DisplayName("대댓글이 정상적으로 작성된다.")
+    void 대댓글이_정상적으로_생성된다(){
+        //given
+        Comment parent = createParentComment();
+
+        //when & then
+        assertDoesNotThrow(() -> createChildComment(parent));
+    }
+
+    @Test
+    @DisplayName("댓글에 상위 댓글이 없으면 True를 반환한다.")
+    void 댓글에_상위_댓글이_없으면_True를_반환한다(){
+        //given
+        Comment parent = createParentComment();
+
+        //when & then
+        assertThat(parent.isParent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("댓글에 달린 대댓글을 삭제한다")
+    void 댓글에_달린_대댓글을_삭제한다(){
+        //given
+        Comment parent = createParentComment();
+        Comment child = createChildComment(parent);
+
+        //when
+        parent.deleteChild(child);
+
+        //then
+        assertThat(parent.hasNoReply()).isTrue();
+    }
+}

--- a/src/test/java/com/donation/domain/embed/MessageTest.java
+++ b/src/test/java/com/donation/domain/embed/MessageTest.java
@@ -1,0 +1,50 @@
+package com.donation.domain.embed;
+
+import com.donation.exception.DonationInvalidateException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class MessageTest {
+
+    @Test
+    @DisplayName("빈 내용으로 댓글을 작성할 경우 예외를 던진다.")
+    void 빈_내용으로_댓글을_작성할_경우_예외를_던진다() {
+        //given & when & then
+        assertThatThrownBy(() -> new Message(""))
+                .isInstanceOf(DonationInvalidateException.class)
+                .hasMessage("댓글의 내용이 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("댓글의 내용이 Null일 경우 예외를 던진다.")
+    void 댓글의_내용이_Null일_경우_예외를_던진다() {
+        //given & when & then
+        assertThatThrownBy(() -> new Message(null))
+                .isInstanceOf(DonationInvalidateException.class)
+                .hasMessage("댓글의 내용이 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("댓글이 100글자를 초과할 경우 예외를 던진다.")
+    void 댓글이_100글자를_초과할_경우_예외를_던진다(){
+        //given
+        String massage = "12345678910".repeat(10);
+
+        //when & then
+        assertThatThrownBy(() -> new Message(massage))
+                .isInstanceOf(DonationInvalidateException.class)
+                .hasMessage("댓글의 길이가 제한을 초과합니다.");
+    }
+
+    @ParameterizedTest
+    @DisplayName("댓글 내용 작성을 성공한다")
+    @ValueSource(strings = {"댓글1", "댓글2 : 테스트 코드 작성입니다.", "안녕하세요"})
+    void 댓글_내용_작성을_성공한다(String message){
+        assertDoesNotThrow(() -> new Message(message));
+    }
+}

--- a/src/test/java/com/donation/repository/comment/CommentRepositoryTest.java
+++ b/src/test/java/com/donation/repository/comment/CommentRepositoryTest.java
@@ -1,0 +1,113 @@
+package com.donation.repository.comment;
+
+
+import com.donation.common.utils.RepositoryTest;
+import com.donation.domain.entites.Comment;
+import com.donation.domain.entites.Post;
+import com.donation.domain.entites.User;
+import com.donation.exception.DonationNotFoundException;
+import com.donation.repository.post.PostRepository;
+import com.donation.repository.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.donation.common.CommentFixtures.*;
+import static com.donation.common.PostFixtures.createPost;
+import static com.donation.common.UserFixtures.createUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+
+public class CommentRepositoryTest extends RepositoryTest {
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Test
+    @DisplayName("댓글을 정상적으로 저장한다")
+    void 댓글을_정상적으로_저장한다(){
+        //given
+        User user = userRepository.save(createUser());
+        Post post = postRepository.save(createPost(user));
+
+        //when & then
+        assertDoesNotThrow(() -> commentRepository.save(createParentComment(user, post)));
+    }
+
+    @Test
+    @DisplayName("존재하는 댓글이 아니면 예외를 던진다")
+    void 존재하는_댓글이_아니면_예외를_던진다(){
+        //given
+        Long id = 0L;
+
+        //when & then
+        assertThatThrownBy(() -> commentRepository.validateExistsById(id))
+                .isInstanceOf(DonationNotFoundException.class)
+                .hasMessage("존재하지 않는 댓글입니다.");
+    }
+
+    @Test
+    @DisplayName("최상위 댓글을 게시물 정보를 통해 조회 한다")
+    void 최상위_댓글을_게시물_정보를_통해_조회_한다(){
+        //given
+        User user = userRepository.save(createUser());
+        Post post = postRepository.save(createPost(user));
+        commentRepository.saveAll(createParentCommentList(0, 10, user, post));
+
+        //when
+        List<Comment> actual = commentRepository.findCommentByPostAndParentIsNull(post);
+
+        //then
+        assertAll(() -> {
+            assertThat(actual.size()).isEqualTo(10);
+            assertThat(actual.get(0).getUser()).isEqualTo(user);
+        });
+    }
+
+    @Test
+    @DisplayName("대댓글을 부모 댓글 정보를 통해 조회한다.")
+    void 대댓글을_부모_댓글_정보를_통해_조회한다(){
+        //given
+        User user = userRepository.save(createUser());
+        Post post = postRepository.save(createPost(user));
+        Comment parent = commentRepository.save(createParentComment(user, post));
+        commentRepository.saveAll(createChildCommentList(0, 10, user, post, parent));
+
+        //when
+        List<Comment> actual = commentRepository.findRepliesByParent(parent);
+
+        //then
+        assertAll(() -> {
+            assertThat(actual.size()).isEqualTo(10);
+            assertThat(actual.get(0).getUser()).isEqualTo(user);
+            assertThat(actual.get(0).getParent()).isEqualTo(parent);
+        });
+    }
+
+    @Test
+    @DisplayName("저장된 댓글 정보를 포스트정보를 통해 모두 삭제한다.")
+    void 저장된_댓글_정보를_포스트정보를_통해_모두_삭제한다(){
+        //given
+        User user = userRepository.save(createUser());
+        Post post = postRepository.save(createPost(user));
+        Comment parent = commentRepository.save(createParentComment(user, post));
+        commentRepository.saveAll(createParentCommentList(0, 5, user, post));
+        commentRepository.saveAll(createChildCommentList(0, 5, user, post, parent));
+
+        //when
+        commentRepository.deleteByPost(post);
+
+        //then
+        assertThat(commentRepository.count()).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/donation/repository/comment/CommentRepositoryTest.java
+++ b/src/test/java/com/donation/repository/comment/CommentRepositoryTest.java
@@ -57,6 +57,30 @@ public class CommentRepositoryTest extends RepositoryTest {
     }
 
     @Test
+    @DisplayName("존재하는 댓글을 댓글ID를 통해 검증한다.")
+    void 존재하는_댓글을_댓글ID를_통해_검증한다(){
+        //given
+        User user = userRepository.save(createUser());
+        Post post = postRepository.save(createPost(user));
+        Long commentId = commentRepository.save(createParentComment(user, post)).getId();
+
+        //when
+        assertDoesNotThrow(() -> commentRepository.validateExistsById(commentId));
+    }
+
+    @Test
+    @DisplayName("존재하는 댓글아닐때 ID로 조회시 예외를 던진다")
+    void 존재하는_댓글아아닐때_ID로_조회시_예외를_던진다(){
+        //given
+        Long id = 0L;
+
+        //when & then
+        assertThatThrownBy(() -> commentRepository.getById(id))
+                .isInstanceOf(DonationNotFoundException.class)
+                .hasMessage("존재하지 않는 댓글입니다.");
+    }
+
+    @Test
     @DisplayName("최상위 댓글을 게시물 정보를 통해 조회 한다")
     void 최상위_댓글을_게시물_정보를_통해_조회_한다(){
         //given

--- a/src/test/java/com/donation/repository/comment/CommentRepositoryTest.java
+++ b/src/test/java/com/donation/repository/comment/CommentRepositoryTest.java
@@ -65,7 +65,7 @@ public class CommentRepositoryTest extends RepositoryTest {
         commentRepository.saveAll(createParentCommentList(0, 10, user, post));
 
         //when
-        List<Comment> actual = commentRepository.findCommentByPostAndParentIsNull(post);
+        List<Comment> actual = commentRepository.findCommentByPostIdAndParentIsNull(post.getId());
 
         //then
         assertAll(() -> {

--- a/src/test/java/com/donation/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/donation/service/comment/CommentServiceTest.java
@@ -1,11 +1,14 @@
 package com.donation.service.comment;
 
 import com.donation.common.utils.ServiceTest;
+import com.donation.domain.entites.Comment;
 import com.donation.domain.entites.Post;
 import com.donation.domain.entites.User;
+import com.donation.exception.DonationInvalidateException;
 import com.donation.repository.comment.CommentRepository;
 import com.donation.repository.post.PostRepository;
 import com.donation.repository.user.UserRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,9 +60,20 @@ public class CommentServiceTest extends ServiceTest {
         //then
         assertThat(commentRepository.existsById(actual)).isTrue();
     }
-//
-//    @Test
-//    @DisplayName("대댓글에 댓글을 추가적으로 작성할 경우 예외가 발생한다.")
-//    void
+
+    @Test
+    @DisplayName("대댓글에 댓글을 추가적으로 작성할 경우 예외가 발생한다.")
+    void 대댓글에_댓글을_추가적으로_작성할_경우_예외가_발생한다(){
+        //given
+        User user = userRepository.save(createUser());
+        Post post = postRepository.save(createPost(user));
+        Comment comment = commentRepository.save(createParentComment(user, post));
+        Comment reply = commentRepository.save(createChildComment(user, post, comment));
+
+        //when & then
+        Assertions.assertThatThrownBy(() -> commentService.saveReply(reply.getId(), user.getId(), 댓글_생성_DTO(일반_대댓글)))
+                .isInstanceOf(DonationInvalidateException.class)
+                .hasMessage("대댓글에는 답글을 달 수 없습니다.");
+    }
 }
 

--- a/src/test/java/com/donation/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/donation/service/comment/CommentServiceTest.java
@@ -75,5 +75,19 @@ public class CommentServiceTest extends ServiceTest {
                 .isInstanceOf(DonationInvalidateException.class)
                 .hasMessage("대댓글에는 답글을 달 수 없습니다.");
     }
+
+    @Test
+    @DisplayName("댓글 작성자가 아닌 다른 사람이 삭제 요청시 예외를 던진다.")
+    void 댓글_작성자가_아닌_다른_사람이_삭제_요청시_예외를_던진다(){
+        //given
+        User user = userRepository.save(createUser());
+        Post post = postRepository.save(createPost(user));
+        Comment comment = commentRepository.save(createParentComment(user, post));
+
+        //when & then
+        Assertions.assertThatThrownBy(() -> commentService.delete(comment.getId(), 0L))
+                .isInstanceOf(DonationInvalidateException.class)
+                .hasMessage("댓글의 작성자만 삭제할 수 있습니다.");
+    }
 }
 

--- a/src/test/java/com/donation/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/donation/service/comment/CommentServiceTest.java
@@ -1,6 +1,7 @@
 package com.donation.service.comment;
 
 import com.donation.common.utils.ServiceTest;
+import com.donation.domain.entites.Post;
 import com.donation.domain.entites.User;
 import com.donation.repository.comment.CommentRepository;
 import com.donation.repository.post.PostRepository;
@@ -9,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static com.donation.common.CommentFixtures.댓글_생성_DTO;
+import static com.donation.common.CommentFixtures.*;
 import static com.donation.common.PostFixtures.createPost;
 import static com.donation.common.UserFixtures.createUser;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,20 +30,36 @@ public class CommentServiceTest extends ServiceTest {
     private CommentRepository commentRepository;
 
     @Test
-    @DisplayName("댓글 정상적으로 작성 완료된다.")
-    void 댓글_정삭적으로_작성_완료(){
+    @DisplayName("댓글 정상적으로 작성이된다.")
+    void 댓글_정삭적으로_작성이된다(){
         //given
         User user = userRepository.save(createUser());
         Long postId = postRepository.save(createPost(user)).getId();
 
         //when
-        Long commentId = commentService.saveComment(postId, user.getId(), 댓글_생성_DTO());
+        Long actual = commentService.saveComment(postId, user.getId(), 댓글_생성_DTO(일반_댓글));
 
         //then
-        assertThat(commentRepository.existsById(commentId)).isTrue();
+        assertThat(commentRepository.existsById(actual)).isTrue();
     }
 
     @Test
-    @DisplayName("대댓글이 정상적으로 작성 완료된다.")
+    @DisplayName("대댓글이 정상적으로 작성이된다.")
+    void 대댓글이_정상적으로_작성이된다(){
+        //given
+        User user = userRepository.save(createUser());
+        Post post = postRepository.save(createPost(user));
+        Long commentId = commentRepository.save(createParentComment(user, post)).getId();
+
+        //when
+        Long actual = commentService.saveReply(commentId, user.getId(), 댓글_생성_DTO(일반_대댓글));
+
+        //then
+        assertThat(commentRepository.existsById(actual)).isTrue();
+    }
+//
+//    @Test
+//    @DisplayName("대댓글에 댓글을 추가적으로 작성할 경우 예외가 발생한다.")
+//    void
 }
 

--- a/src/test/java/com/donation/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/donation/service/comment/CommentServiceTest.java
@@ -1,0 +1,48 @@
+package com.donation.service.comment;
+
+import com.donation.common.utils.ServiceTest;
+import com.donation.domain.entites.User;
+import com.donation.repository.comment.CommentRepository;
+import com.donation.repository.post.PostRepository;
+import com.donation.repository.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.donation.common.CommentFixtures.댓글_생성_DTO;
+import static com.donation.common.PostFixtures.createPost;
+import static com.donation.common.UserFixtures.createUser;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommentServiceTest extends ServiceTest {
+
+    @Autowired
+    private CommentService commentService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Test
+    @DisplayName("댓글 정상적으로 작성 완료된다.")
+    void 댓글_정삭적으로_작성_완료(){
+        //given
+        User user = userRepository.save(createUser());
+        Long postId = postRepository.save(createPost(user)).getId();
+
+        //when
+        Long commentId = commentService.saveComment(postId, user.getId(), 댓글_생성_DTO());
+
+        //then
+        assertThat(commentRepository.existsById(commentId)).isTrue();
+    }
+
+    @Test
+    @DisplayName("대댓글이 정상적으로 작성 완료된다.")
+}
+

--- a/src/test/java/com/donation/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/donation/service/comment/CommentServiceTest.java
@@ -182,17 +182,17 @@ public class CommentServiceTest extends ServiceTest {
         //given
         User user = userRepository.save(createUser());
         Post post = postRepository.save(createPost(user));
-        List<Comment> comments = commentRepository.saveAll(createParentCommentList(0, 5, user, post));
-        List<Comment> replies = commentRepository.saveAll(createChildCommentList(0, 5, user, post, comments.get(0)));
+        Comment parent = commentRepository.saveAll(createParentCommentList(0, 5, user, post)).get(0);
+        commentRepository.saveAll(createChildCommentList(0, 5, user, post, parent));
 
         //when
-        commentService.delete(comments.get(0).getId(), user.getId());
+        commentService.delete(parent.getId(), user.getId());
         List<CommentResponse> actual = commentService.findComment(post.getId());
 
         //then
         assertAll(() -> {
             assertThat(commentRepository.count()).isEqualTo(10);
-            assertThat(actual.size()).isEqualTo(4);
+            assertThat(actual.size()).isEqualTo(5);
         });
     }
 }

--- a/src/test/java/com/donation/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/donation/service/comment/CommentServiceTest.java
@@ -121,5 +121,22 @@ public class CommentServiceTest extends ServiceTest {
         //then
         assertThat(actual.isSoftRemoved()).isTrue();
     }
+
+    @Test
+    @DisplayName("대댓글 삭제 요청 성공")
+    void 대댓글_삭제_요청_성공(){
+        //given
+        User user = userRepository.save(createUser());
+        Post post = postRepository.save(createPost(user));
+        Long commentId = commentRepository.save(createParentComment(user, post)).getId();
+        Long replyId = commentService.saveReply(commentId, user.getId(), 댓글_생성_DTO(일반_대댓글));
+
+        //when
+        commentService.delete(replyId, user.getId());
+
+        //then
+        assertThat(commentRepository.existsById(replyId)).isFalse();
+    }
+
 }
 

--- a/src/test/java/com/donation/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/donation/service/comment/CommentServiceTest.java
@@ -22,13 +22,10 @@ public class CommentServiceTest extends ServiceTest {
 
     @Autowired
     private CommentService commentService;
-
     @Autowired
     private UserRepository userRepository;
-
     @Autowired
     private PostRepository postRepository;
-
     @Autowired
     private CommentRepository commentRepository;
 
@@ -138,5 +135,21 @@ public class CommentServiceTest extends ServiceTest {
         assertThat(commentRepository.existsById(replyId)).isFalse();
     }
 
+    @Test
+    @DisplayName("댓글 삭제 요청 후 해당 대댓글이 삭제된다면 해당 부모 댓글도 삭제된다.")
+    void 댓글_삭제_요청_후_해당_대댓글이_삭제된다면_해당_부모댓글도_삭제된다(){
+        //given
+        User user = userRepository.save(createUser());
+        Post post = postRepository.save(createPost(user));
+        Long commentId = commentRepository.save(createParentComment(user, post)).getId();
+        Long replyId = commentService.saveReply(commentId, user.getId(), 댓글_생성_DTO(일반_대댓글));
+
+        //when
+        commentService.delete(commentId, user.getId());
+        commentService.delete(replyId, user.getId());
+
+        //then
+        assertThat(commentRepository.count()).isEqualTo(0);
+    }
 }
 

--- a/src/test/java/com/donation/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/donation/service/comment/CommentServiceTest.java
@@ -105,6 +105,21 @@ public class CommentServiceTest extends ServiceTest {
         assertThat(commentRepository.existsById(commentId)).isFalse();
     }
 
+    @Test
+    @DisplayName("대댓글이 존재하는 댓글 삭제 요청 성공")
+    void 대댓글이_존재하는_댓글_삭제_요청_성공() {
+        //given
+        User user = userRepository.save(createUser());
+        Post post = postRepository.save(createPost(user));
+        Long commentId = commentRepository.save(createParentComment(user, post)).getId();
+        commentService.saveReply(commentId, user.getId(), 댓글_생성_DTO(일반_대댓글));
 
+        //when
+        commentService.delete(commentId, user.getId());
+        Comment actual = commentRepository.getById(commentId);
+
+        //then
+        assertThat(actual.isSoftRemoved()).isTrue();
+    }
 }
 

--- a/src/test/java/com/donation/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/donation/service/comment/CommentServiceTest.java
@@ -34,7 +34,7 @@ public class CommentServiceTest extends ServiceTest {
 
     @Test
     @DisplayName("댓글 정상적으로 작성이된다.")
-    void 댓글_정삭적으로_작성이된다(){
+    void 댓글_정삭적으로_작성이된다() {
         //given
         User user = userRepository.save(createUser());
         Long postId = postRepository.save(createPost(user)).getId();
@@ -48,7 +48,7 @@ public class CommentServiceTest extends ServiceTest {
 
     @Test
     @DisplayName("대댓글이 정상적으로 작성이된다.")
-    void 대댓글이_정상적으로_작성이된다(){
+    void 대댓글이_정상적으로_작성이된다() {
         //given
         User user = userRepository.save(createUser());
         Post post = postRepository.save(createPost(user));
@@ -63,7 +63,7 @@ public class CommentServiceTest extends ServiceTest {
 
     @Test
     @DisplayName("대댓글에 댓글을 추가적으로 작성할 경우 예외가 발생한다.")
-    void 대댓글에_댓글을_추가적으로_작성할_경우_예외가_발생한다(){
+    void 대댓글에_댓글을_추가적으로_작성할_경우_예외가_발생한다() {
         //given
         User user = userRepository.save(createUser());
         Post post = postRepository.save(createPost(user));
@@ -78,16 +78,33 @@ public class CommentServiceTest extends ServiceTest {
 
     @Test
     @DisplayName("댓글 작성자가 아닌 다른 사람이 삭제 요청시 예외를 던진다.")
-    void 댓글_작성자가_아닌_다른_사람이_삭제_요청시_예외를_던진다(){
+    void 댓글_작성자가_아닌_다른_사람이_삭제_요청시_예외를_던진다() {
         //given
         User user = userRepository.save(createUser());
         Post post = postRepository.save(createPost(user));
-        Comment comment = commentRepository.save(createParentComment(user, post));
+        Long commentId = commentRepository.save(createParentComment(user, post)).getId();
 
         //when & then
-        Assertions.assertThatThrownBy(() -> commentService.delete(comment.getId(), 0L))
+        Assertions.assertThatThrownBy(() -> commentService.delete(commentId, 0L))
                 .isInstanceOf(DonationInvalidateException.class)
                 .hasMessage("댓글의 작성자만 삭제할 수 있습니다.");
     }
+
+    @Test
+    @DisplayName("대댓글이 존재하지 않는 댓글 삭제 요청 성공")
+    void 대댓글이_존재하지_않는_댓글_삭제_요청_성공() {
+        //given
+        User user = userRepository.save(createUser());
+        Post post = postRepository.save(createPost(user));
+        Long commentId = commentRepository.save(createParentComment(user, post)).getId();
+
+        //when
+        commentService.delete(commentId, user.getId());
+
+        //then
+        assertThat(commentRepository.existsById(commentId)).isFalse();
+    }
+
+
 }
 

--- a/src/test/java/com/donation/service/donation/DonationServiceTest.java
+++ b/src/test/java/com/donation/service/donation/DonationServiceTest.java
@@ -4,17 +4,16 @@ import com.donation.common.request.donation.DonationFilterReqDto;
 import com.donation.common.request.donation.DonationSaveReqDto;
 import com.donation.common.response.donation.DonationFindByFilterRespDto;
 import com.donation.common.response.donation.DonationFindRespDto;
+import com.donation.common.utils.ServiceTest;
 import com.donation.domain.entites.Donation;
 import com.donation.domain.entites.Post;
 import com.donation.domain.entites.User;
 import com.donation.repository.donation.DonationRepository;
 import com.donation.repository.post.PostRepository;
 import com.donation.repository.user.UserRepository;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -28,8 +27,8 @@ import static com.donation.common.TestEntityDataFactory.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SpringBootTest
-class DonationServiceTest {
+
+class DonationServiceTest extends ServiceTest {
     @Autowired
     private DonationService donationService;
     @Autowired
@@ -39,12 +38,6 @@ class DonationServiceTest {
     @Autowired
     private UserRepository userRepository;
 
-    @AfterEach
-    void clear(){
-        donationRepository.deleteAll();
-        postRepository.deleteAll();
-        userRepository.deleteAll();
-    }
 
     @Test
     @DisplayName("후원(서비스) :  후원하기_예외발생")


### PR DESCRIPTION
### 댓글 기능 추가했습니다
  - 댓글 작성 구현
  - 대댓글 작성 구현
  - 댓글 리스트 조회 구현
  - 댓글 삭제 구현
## 동작 방식
- 댓글 저장 : 포스트 ID를 통해서 댓글을 작성할 수 있습니다.
   -  포스트 ID, 유저ID를 통해 검증을 합니다.
   -  엔티티내 댓글의 글자가 없거나 100자 이상일 경우 예외를 발생시킵니다.
``` java
@Transactional
public Long saveComment(final Long postId,final Long userId, final CommentSaveReqDto commentSaveReqDto){
    Post post = postRepository.getById(postId);
    User user = userRepository.getById(userId);
    Comment comment = Comment.parent(user, post, commentSaveReqDto.getMessage());
    return commentRepository.save(comment).getId();
}
```
- 대댓글 저장 : 기존 부모 댓글 ID를 통해 대댓글을 작성할 수 있습니다.
  - 대댓글에 추가 대댓글을 작성할 경우 예외를 발생시킵니다.
  - 부모 댓글이 존재하지않으면 예외를 발생시킵니다.  
``` java
@Transactional
public Long saveReply(final Long commentId, final Long userId, final CommentSaveReqDto commentSaveReqDto){
    Comment child = validateReplySave(commentId, userId, commentSaveReqDto);
    return commentRepository.save(child).getId();
}
``` 
- 댓글 전체 조회 : 포스트 ID를 통해 댓글을 조회합니다.
``` java
public List<CommentResponse> findComment(final Long postId){
    return commentRepository.findCommentByPostIdAndParentIsNull(postId).stream()
            .map(this::convertToCommentResponse)
            .collect(Collectors.toList());
}
```
- 댓글 삭제 : 댓글 ID를 통해 댓글을 삭제합니다.
  - 댓글 삭제에 경우 하위 대댓글이 많이 달린경우 부모댓글을 삭제한다면 수많은 쿼리가 나갈것으로 예상되어 로직을 다르게 구성했습니다.
     - 최상위 댓글이 삭제될때 하위 댓글이 존재하지 않으면 최상위 댓글을 삭제한다.
     - 최상위 댓글에 하위 댓글이 존재한다면 최상위 댓글의 상태만 TRUE로 변경한다.
     - 최상위 댓글에 하위 댓글이 모두 삭제됬을때 최상의 댓글의 상태가 TRUE라면 최상위 댓글또한 삭제한다.
   - 위와 같은 방식으로 최소 0번, 최대 2번의 쿼리로 로직을 구성했습니다.
``` java
public List<CommentResponse> findComment(final Long postId){
    return commentRepository.findCommentByPostIdAndParentIsNull(postId).stream()
            .map(this::convertToCommentResponse)
            .collect(Collectors.toList());
}
```