### PR TITLE
refactor: Auth 로직 추가로 인한 User Controller 코드 수정

### DIFF
--- a/src/docs/asciidoc/api/User-API.adoc
+++ b/src/docs/asciidoc/api/User-API.adoc
@@ -13,11 +13,11 @@ include::{snippets}/user-login/response-fields.adoc[]
 
 == 유저 정보 단건 조회
 === 요청
-include::{snippets}/user-inquiry/http-request.adoc[]
-include::{snippets}/user-inquiry/path-parameters.adoc[]
+include::{snippets}/user-me/http-request.adoc[]
+include::{snippets}/user-me/request-headers.adoc[]
 === 응답
-include::{snippets}/user-inquiry/http-response.adoc[]
-include::{snippets}/user-inquiry/response-fields.adoc[]
+include::{snippets}/user-me/http-response.adoc[]
+include::{snippets}/user-me/response-fields.adoc[]
 
 == 유저 정보 리스트 조회
 === 요청
@@ -27,5 +27,7 @@ include::{snippets}/user-getList/http-response.adoc[]
 
 == 유저 프로필 사진 업데이트
 include::{snippets}/user-profileImage/http-request.adoc[]
+include::{snippets}/user-profileImage/request-headers.adoc[]
+include::{snippets}/user-profileImage/request-fields.adoc[]
 === 응답
 include::{snippets}/user-profileImage/http-response.adoc[]

--- a/src/main/java/com/donation/common/request/post/PostSaveReqDto.java
+++ b/src/main/java/com/donation/common/request/post/PostSaveReqDto.java
@@ -6,12 +6,16 @@ import com.donation.domain.entites.User;
 import com.donation.domain.enums.Category;
 import com.donation.domain.enums.PostState;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-@Data
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor
 public class PostSaveReqDto {
 
     @NotBlank(message = "제목이 없습니다.")

--- a/src/main/java/com/donation/common/request/post/PostUpdateReqDto.java
+++ b/src/main/java/com/donation/common/request/post/PostUpdateReqDto.java
@@ -3,12 +3,14 @@ package com.donation.common.request.post;
 import com.donation.domain.embed.Write;
 import com.donation.domain.enums.Category;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-@Data
+@Getter
+@NoArgsConstructor
 public class PostUpdateReqDto {
     @NotBlank(message = "제목이 없습니다.")
     private String title;

--- a/src/main/java/com/donation/common/request/user/UserLoginReqDto.java
+++ b/src/main/java/com/donation/common/request/user/UserLoginReqDto.java
@@ -16,12 +16,9 @@ public class UserLoginReqDto {
     @NotBlank
     private String password;
 
-    private String refreshToken;
-
     @Builder
-    public UserLoginReqDto(final String email, final String password, final String refreshToken) {
+    public UserLoginReqDto(final String email, final String password) {
         this.email = email;
         this.password = password;
-        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/donation/service/user/UserService.java
+++ b/src/main/java/com/donation/service/user/UserService.java
@@ -1,5 +1,6 @@
 package com.donation.service.user;
 
+import com.donation.auth.LoginMember;
 import com.donation.common.request.user.UserProfileUpdateReqDto;
 import com.donation.common.response.user.UserRespDto;
 import com.donation.domain.entites.User;
@@ -22,13 +23,13 @@ public class UserService {
     private final UserRepository userRepository;
     private final AwsS3Service awsS3Service;
 
-    public UserRespDto findById(Long id){
-        return UserRespDto.of(userRepository.getById(id));
+    public UserRespDto findById(LoginMember loginMember){
+        return UserRespDto.of(userRepository.getById(loginMember.getId()));
     }
 
     @Transactional
-    public void updateProfile(Long id, UserProfileUpdateReqDto userProfileUpdateReqDto){
-        User user = userRepository.getById(id);
+    public void updateProfile(LoginMember loginMember, UserProfileUpdateReqDto userProfileUpdateReqDto){
+        User user = userRepository.getById(loginMember.getId());
         user.changeNewProfileImage(awsS3Service.upload(userProfileUpdateReqDto.getProfileImage()));
     }
 

--- a/src/main/java/com/donation/web/controller/user/UserController.java
+++ b/src/main/java/com/donation/web/controller/user/UserController.java
@@ -1,5 +1,7 @@
 package com.donation.web.controller.user;
 
+import com.donation.auth.LoginInfo;
+import com.donation.auth.LoginMember;
 import com.donation.common.CommonResponse;
 import com.donation.common.request.user.UserLoginReqDto;
 import com.donation.common.request.user.UserProfileUpdateReqDto;
@@ -28,8 +30,8 @@ public class UserController {
 
     @PostMapping("/join")
     public ResponseEntity<Void> join(@RequestBody @Valid UserSaveReqDto userSaveReqDto) {
-        Long id = authService.save(userSaveReqDto);
-        return ResponseEntity.created(URI.create("/api/user/" + id)).build();
+        authService.save(userSaveReqDto);
+        return ResponseEntity.created(URI.create("/api/user/me")).build();
     }
 
     @PostMapping("/login")
@@ -44,17 +46,17 @@ public class UserController {
         return ResponseEntity.ok(CommonResponse.success(users));
     }
 
-    @GetMapping("/user/{id}")
-    public ResponseEntity<?> get(@PathVariable Long id){
-        UserRespDto userRespDto = userService.findById(id);
+    @GetMapping("/user/me")
+    public ResponseEntity<?> get(@LoginInfo LoginMember loginMember){
+        UserRespDto userRespDto = userService.findById(loginMember);
         return ResponseEntity.ok(CommonResponse.success(userRespDto));
     }
 
-    @PutMapping("/user/{id}/profile")
+    @PutMapping("/user/profile")
     public ResponseEntity<?> editProfile(
-            @PathVariable Long id,
+            @LoginInfo LoginMember loginMember,
             @Valid @RequestBody UserProfileUpdateReqDto profileUpdateReqDto){
-        userService.updateProfile(id, profileUpdateReqDto);
+        userService.updateProfile(loginMember, profileUpdateReqDto);
         return ResponseEntity.ok(CommonResponse.success());
     }
 }

--- a/src/main/resources/templates/docs/index.html
+++ b/src/main/resources/templates/docs/index.html
@@ -473,7 +473,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-11-06 20:33:06 +0900
+Last updated 2022-11-06 21:03:49 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/com/donation/common/AuthFixtures.java
+++ b/src/test/java/com/donation/common/AuthFixtures.java
@@ -9,13 +9,13 @@ import com.donation.service.auth.domain.AuthToken;
 public class AuthFixtures {
 
 
-    public static final String 엑세스_토큰 = "aaaaa.bbbbb.ccccc";
-    public static final String 리프레시_토큰 = "ccccc.bbbbb.aaaaa";
-    public static final String 리뉴얼_엑세스_토큰 = "bbbbb.ccccc.aaaaa";
+    public static final String 엑세스_토큰 = "aaaaaaaaaa.bbbbbbbbbb.ccccccccc";
+    public static final String 리프레시_토큰 = "ccccccccc.bbbbbbbbbb.aaaaaaaaaa";
+    public static final String 리뉴얼_엑세스_토큰 = "bbbbbbbbbb.ccccccccc.aaaaaaaaaa";
     public static final String 토큰_정보 = "Bearer " + 엑세스_토큰;
     public static final String AUTHORIZATION_HEADER_NAME = "Authorization";
 
-    public static LoginMember 로그인정보(Long id){
+    public static LoginMember 회원검증(Long id){
         return new LoginMember(id);
     }
 

--- a/src/test/java/com/donation/common/AuthFixtures.java
+++ b/src/test/java/com/donation/common/AuthFixtures.java
@@ -1,5 +1,6 @@
 package com.donation.common;
 
+import com.donation.auth.LoginMember;
 import com.donation.common.request.auth.TokenRenewalRequest;
 import com.donation.common.response.auth.AccessAndRefreshTokenResponse;
 import com.donation.common.response.auth.AccessTokenResponse;
@@ -13,6 +14,10 @@ public class AuthFixtures {
     public static final String 리뉴얼_엑세스_토큰 = "bbbbb.ccccc.aaaaa";
     public static final String 토큰_정보 = "Bearer " + 엑세스_토큰;
     public static final String AUTHORIZATION_HEADER_NAME = "Authorization";
+
+    public static LoginMember 로그인정보(Long id){
+        return new LoginMember(id);
+    }
 
     public static AuthToken 토큰(){
         return AuthToken.builder()

--- a/src/test/java/com/donation/common/UserFixtures.java
+++ b/src/test/java/com/donation/common/UserFixtures.java
@@ -25,7 +25,7 @@ public class UserFixtures {
     /* 회원가입 데이터 */
     public static UserSaveReqDto 유저_회원가입_DTO = new UserSaveReqDto(일반_사용자_이메일, 일반_사용자_이름, 일반_사용자_패스워드, 일반_사용자_메타마스크_주소);
     /* 로그인 데이터 */
-    public static UserLoginReqDto 유저_로그인_DTO = new UserLoginReqDto(일반_사용자_이메일, 일반_사용자_패스워드, "refreshToken");
+    public static UserLoginReqDto 유저_로그인_DTO = new UserLoginReqDto(일반_사용자_이메일, 일반_사용자_패스워드);
     /* 업데이트 데이터 */
 
 

--- a/src/test/java/com/donation/controller/user/UserControllerTest.java
+++ b/src/test/java/com/donation/controller/user/UserControllerTest.java
@@ -1,5 +1,6 @@
 package com.donation.controller.user;
 
+import com.donation.auth.LoginMember;
 import com.donation.common.UserFixtures;
 import com.donation.common.response.user.UserRespDto;
 import com.donation.common.utils.ControllerTest;
@@ -18,22 +19,20 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
-import static com.donation.common.AuthFixtures.로그인_응답_DTO;
+import static com.donation.common.AuthFixtures.*;
 import static com.donation.common.UserFixtures.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 
 @WebMvcTest(UserController.class)
 class UserControllerTest extends ControllerTest {
@@ -69,7 +68,7 @@ class UserControllerTest extends ControllerTest {
     @DisplayName("로그인 요청 성공")
     void 로그인_요청_성공() throws Exception {
         //given
-        given(authService.login(유저_로그인_DTO)).willReturn(로그인_응답_DTO());
+        given(authService.login(any())).willReturn(로그인_응답_DTO());
 
         // expected
         mockMvc.perform(post("/api/login")
@@ -80,7 +79,13 @@ class UserControllerTest extends ControllerTest {
                 .andDo(print())
                 .andDo(document("user-login",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data.accessToken").description("엑세스 토큰"),
+                                fieldWithPath("data.refreshToken").description("리프레시 토큰"),
+                                fieldWithPath("error").description("에러 발생시 오류 반환")
+                        )
                 ));
     }
 
@@ -89,15 +94,18 @@ class UserControllerTest extends ControllerTest {
     void 회원의_ID를_통한_회원단건조회_요청_성공() throws Exception {
         //given
         Long id = 1L;
-        given(userService.findById(id)).willReturn(일반_반환_데이터(id));
+        given(userService.findById(any())).willReturn(일반_반환_데이터(id));
+        given(authService.extractMemberId(엑세스_토큰)).willReturn(id);
 
         // expected
-        mockMvc.perform(get("/api/user/{id}", id))
+        mockMvc.perform(get("/api/user/me")
+                        .header(AUTHORIZATION_HEADER_NAME, 토큰_정보))
                 .andExpect(status().isOk())
-                .andDo(document("user-inquiry",
+                .andDo(print())
+                .andDo(document("user-me",
                         preprocessResponse(prettyPrint()),
-                        pathParameters(
-                                parameterWithName("id").description("유저 ID")
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION_HEADER_NAME).description("JWT 엑세스 토큰")
                         ),
                         responseFields(
                                 fieldWithPath("success").description("성공 여부"),
@@ -133,16 +141,26 @@ class UserControllerTest extends ControllerTest {
     void 회원_프로필_수정_요청_성공() throws Exception {
         //given
         Long id = 1L;
-        willDoNothing().given(userService).updateProfile(id, 유저_프로필_업데이트_DTO);
+        LoginMember 로그인정보 = new LoginMember(id);
+        willDoNothing().given(userService).updateProfile(로그인정보, 유저_프로필_업데이트_DTO);
+        given(authService.extractMemberId(엑세스_토큰)).willReturn(id);
 
         //expected
-        mockMvc.perform(put("/api/user/{id}/profile", id)
+        mockMvc.perform(put("/api/user/profile")
+                        .header(AUTHORIZATION_HEADER_NAME, 토큰_정보)
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(유저_프로필_업데이트_DTO)))
                 .andExpect(status().isOk())
                 .andDo(document("user-profileImage",
                         preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION_HEADER_NAME).description("JWT 엑세스 토큰")
+                        ),
+                        requestFields(
+                                fieldWithPath("profileImage").description("Base64 인코딩 이미지")
+                        )
+
                 ));
     }
 }

--- a/src/test/java/com/donation/service/auth/AuthServiceTest.java
+++ b/src/test/java/com/donation/service/auth/AuthServiceTest.java
@@ -108,7 +108,7 @@ public class AuthServiceTest extends ServiceTest {
     void 다른_패스워드로_로그인_요청시_예외_발생(){
         //given
         authService.save(유저_회원가입_DTO);
-        UserLoginReqDto 예외발생요청 = new UserLoginReqDto(일반_사용자_이메일, "다른패스워드", null);
+        UserLoginReqDto 예외발생요청 = new UserLoginReqDto(일반_사용자_이메일, "다른패스워드");
 
         //given & when & then
         assertThatThrownBy(() -> authService.login(예외발생요청))

--- a/src/test/java/com/donation/service/user/UserServiceTest.java
+++ b/src/test/java/com/donation/service/user/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.donation.service.user;
 
+import com.donation.auth.LoginMember;
 import com.donation.common.response.user.UserRespDto;
 import com.donation.common.utils.ServiceTest;
 import com.donation.domain.entites.User;
@@ -51,9 +52,9 @@ class UserServiceTest extends ServiceTest {
     void 저장된_회원_새로운_프로필_등록(){
         //given
         User user = userRepository.save(createUser());
-
+        LoginMember loginMember = new LoginMember(user.getId());
         //when
-        userService.updateProfile(user.getId(), 유저_프로필_업데이트_DTO);
+        userService.updateProfile(loginMember, 유저_프로필_업데이트_DTO);
 
         //then
         User actual = userRepository.getById(user.getId());
@@ -68,9 +69,10 @@ class UserServiceTest extends ServiceTest {
     void 회원_ID를_통해_회원_조회() {
         //given
         User user = userRepository.save(createUser());
+        LoginMember loginMember = new LoginMember(user.getId());
 
         //when
-        UserRespDto dto = userService.findById(user.getId());
+        UserRespDto dto = userService.findById(loginMember);
 
         //then
         assertThat(dto.getEmail()).isEqualTo(user.getEmail());


### PR DESCRIPTION
## 수정사항
- 유저 단건 조회시 토큰을 이용한 검사 
- 유저 프로필 사진 업데이트시 토큰을 이용한 검사

## 수정 코드
- 단건 조회
``` java
  @GetMapping("/user/me")
  public ResponseEntity<?> get(@LoginInfo LoginMember loginMember){
  UserRespDto userRespDto = userService.findById(loginMember);
        return ResponseEntity.ok(CommonResponse.success(userRespDto));
  }
```
- 프로필 업데이트
``` java
@PutMapping("/user/profile")
public ResponseEntity<?> editProfile(
       @LoginInfo LoginMember loginMember,
       @Valid @RequestBody UserProfileUpdateReqDto profileUpdateReqDto){
   userService.updateProfile(loginMember, profileUpdateReqDto);
   return ResponseEntity.ok(CommonResponse.success());
}
```
## 체크사항
- `MvcMock` 을 사용하여 `given(any())...` 코드를 사용할때, 객체 비교시 `willReturn`에서 `null` 을 반환하는 상태 발생
- 해결방법 : `@EqualsAndHashCode` 사용 및 구현